### PR TITLE
feat: support multiple compiler versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,9 @@ serde = "1.0.130"
 hex = "0.4.3"
 regex = { version = "1.5.4", default-features = false }
 
-svm = { package = "solc-vm-rs", git = "https://github.com/roynalnaruto/solc-vm-rs" }
+svm = { package = "svm-rs", git = "https://github.com/roynalnaruto/svm-rs" }
 glob = "0.3.0"
 semver = "1.0.4"
 
 [patch.'crates-io']
-ethabi = { git = "https://github.com/gakonst/ethabi/", branch = "patch-1" }
 evm = { git = "https://github.com/gakonst/evm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ serde = "1.0.130"
 hex = "0.4.3"
 regex = { version = "1.5.4", default-features = false }
 
+svm = { package = "solc-vm-rs", git = "https://github.com/roynalnaruto/solc-vm-rs" }
+glob = "0.3.0"
+semver = "1.0.4"
+
 [patch.'crates-io']
 ethabi = { git = "https://github.com/gakonst/ethabi/", branch = "patch-1" }
 evm = { git = "https://github.com/gakonst/evm" }

--- a/FooTest.sol
+++ b/FooTest.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.1;
+
+contract Foo {
+    uint256 x;
+
+    function setUp() public {
+        x = 1;
+    }
+
+    function testX() public {
+        require(x == 1, "x is not one");
+    }
+}

--- a/FooTest2.sol
+++ b/FooTest2.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.1;
+
+contract FooBar {
+    uint256 x;
+
+    function setUp() public {
+        x = 1;
+    }
+
+    function testX() public {
+        require(x == 1, "x is not one");
+    }
+}

--- a/GreetTest.sol
+++ b/GreetTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.6;
+pragma solidity =0.7.6;
 
 contract Greeter {
     string public greeting;

--- a/src/dapp.rs
+++ b/src/dapp.rs
@@ -587,10 +587,11 @@ mod tests {
 
     #[test]
     fn can_call_vm_directly() {
-        // TODO: Is there a cleaner way to initialize them all together in a function?
         let cfg = Config::istanbul();
-
-        let compiled = Solc::new(&format!("./GreetTest.sol")).build().unwrap();
+        let compiled = SolcBuilder::new("./*.sol", &[], &[])
+            .unwrap()
+            .build_all()
+            .unwrap();
         let compiled = compiled.get("Greeter").expect("could not find contract");
 
         let addr = "0x1000000000000000000000000000000000000000"
@@ -630,7 +631,10 @@ mod tests {
     fn solidity_unit_test() {
         let cfg = Config::istanbul();
 
-        let compiled = Solc::new(&format!("./GreetTest.sol")).build().unwrap();
+        let compiled = SolcBuilder::new("./*.sol", &[], &[])
+            .unwrap()
+            .build_all()
+            .unwrap();
         let compiled = compiled
             .get("GreeterTest")
             .expect("could not find contract");
@@ -672,7 +676,10 @@ mod tests {
     fn failing_with_no_reason_if_no_setup() {
         let cfg = Config::istanbul();
 
-        let compiled = Solc::new(&format!("./GreetTest.sol")).build().unwrap();
+        let compiled = SolcBuilder::new("./*.sol", &[], &[])
+            .unwrap()
+            .build_all()
+            .unwrap();
         let compiled = compiled
             .get("GreeterTest")
             .expect("could not find contract");
@@ -702,7 +709,10 @@ mod tests {
     fn failing_solidity_unit_test() {
         let cfg = Config::istanbul();
 
-        let compiled = Solc::new(&format!("./GreetTest.sol")).build().unwrap();
+        let compiled = SolcBuilder::new("./*.sol", &[], &[])
+            .unwrap()
+            .build_all()
+            .unwrap();
         let compiled = compiled
             .get("GreeterTest")
             .expect("could not find contract");
@@ -745,7 +755,10 @@ mod tests {
     fn test_runner() {
         let cfg = Config::istanbul();
 
-        let compiled = Solc::new(&format!("./GreetTest.sol")).build().unwrap();
+        let compiled = SolcBuilder::new("./*.sol", &[], &[])
+            .unwrap()
+            .build_all()
+            .unwrap();
         let compiled = compiled
             .get("GreeterTest")
             .expect("could not find contract");

--- a/src/dapp.rs
+++ b/src/dapp.rs
@@ -377,13 +377,13 @@ impl<'a> MultiContractRunner<'a> {
                         println!("Installing {}", upstream_version);
                         tokio::runtime::Runtime::new()?
                             .block_on(svm::install(&upstream_version))?;
+                        println!("Done!");
                         found_version = Some(upstream_version);
                     }
                 }
 
-                // we did not find a version
+                // we found a version
                 if let Some(found_version) = found_version {
-                    println!("Found latest version: {}", &found_version);
                     let entry = contracts_by_version.entry(found_version).or_insert(vec![]);
                     entry.push(path);
                 }
@@ -402,8 +402,7 @@ impl<'a> MultiContractRunner<'a> {
                     .clone();
                 compiler_path.push(format!("solc-{}", &version));
 
-                let files = files.join(",");
-                let mut solc = Solc::new(&files).solc_path(compiler_path);
+                let mut solc = Solc::new_with_paths(files).solc_path(compiler_path);
                 let lib_paths = lib_paths
                     .iter()
                     .filter(|path| !path.is_empty())

--- a/src/dapp.rs
+++ b/src/dapp.rs
@@ -11,7 +11,7 @@ use evm::{Config, Handler};
 use evm::{ExitReason, ExitRevert, ExitSucceed};
 use std::{
     collections::{BTreeMap, HashMap},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use eyre::Result;
@@ -340,7 +340,7 @@ impl<'a> SolcBuilder<'a> {
             .filter_map(|fname| fname.ok())
             .filter_map(|fname| self.detect_version(fname).ok().flatten())
             .fold(HashMap::new(), |mut map, (version, path)| {
-                let entry = map.entry(version.to_string()).or_insert(vec![]);
+                let entry = map.entry(version.to_string()).or_insert_with(Vec::new);
                 entry.push(path);
                 map
             }))
@@ -348,7 +348,7 @@ impl<'a> SolcBuilder<'a> {
 
     /// Parses the given Solidity file looking for the `pragma` definition and
     /// returns the corresponding SemVer version requirement.
-    fn version_req(path: &PathBuf) -> Result<VersionReq> {
+    fn version_req(path: &Path) -> Result<VersionReq> {
         let file = BufReader::new(File::open(path)?);
         let version = file
             .lines()

--- a/src/dapp.rs
+++ b/src/dapp.rs
@@ -289,15 +289,181 @@ impl DapptoolsArtifact {
 }
 
 pub fn installed_version_paths() -> Result<Vec<PathBuf>> {
-    let home_dir = svm::home();
+    let home_dir = svm::SVM_HOME.clone();
     let mut versions = vec![];
-    for version in std::fs::read_dir(&home_dir)? {
+    for version in std::fs::read_dir(home_dir)? {
         let version = version?;
         versions.push(version.path());
     }
 
     versions.sort();
     Ok(versions)
+}
+
+/// Supports building contracts
+struct SolcBuilder<'a> {
+    contracts: &'a str,
+    remappings: &'a [String],
+    lib_paths: &'a [String],
+    versions: Vec<Version>,
+    releases: Vec<Version>,
+}
+
+use semver::{Version, VersionReq};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+impl<'a> SolcBuilder<'a> {
+    pub fn new(
+        contracts: &'a str,
+        remappings: &'a [String],
+        lib_paths: &'a [String],
+    ) -> Result<Self> {
+        let versions = svm::installed_versions().unwrap_or_default();
+        let releases = tokio::runtime::Runtime::new()?.block_on(svm::all_versions())?;
+        Ok(Self {
+            contracts,
+            remappings,
+            lib_paths,
+            versions,
+            releases,
+        })
+    }
+
+    /// Gets a map of compiler version -> vec[contract paths]
+    fn contract_versions(&mut self) -> Result<HashMap<String, Vec<String>>> {
+        // Group contracts in the nones with the same version pragma
+        let files = glob::glob(self.contracts)?;
+
+        // get all the corresponding contract versions
+        Ok(files
+            .filter_map(|fname| fname.ok())
+            .filter_map(|fname| self.detect_version(fname).ok().flatten())
+            .fold(HashMap::new(), |mut map, (version, path)| {
+                let entry = map.entry(version.to_string()).or_insert(vec![]);
+                entry.push(path);
+                map
+            }))
+    }
+
+    /// Parses the given Solidity file looking for the `pragma` definition and
+    /// returns the corresponding SemVer version requirement.
+    fn version_req(path: &PathBuf) -> Result<VersionReq> {
+        let file = BufReader::new(File::open(path)?);
+        let version = file
+            .lines()
+            .map(|line| line.unwrap())
+            .find(|line| line.starts_with("pragma"))
+            .ok_or_else(|| eyre::eyre!("{:?} has no version", path))?;
+        let version = version
+            .replace("pragma solidity ", "")
+            .replace(";", "")
+            // needed to make it valid semver for things like
+            // >=0.4.0 <0.5.0
+            .replace(" ", ",");
+
+        Ok(VersionReq::parse(&version)?)
+    }
+
+    /// Find a matching local installation for the specified required version
+    fn find_matching_installation(
+        &self,
+        versions: &[Version],
+        required_version: &VersionReq,
+    ) -> Option<Version> {
+        versions
+            .iter()
+            // filter these out, unneeded artifact from solc-vm-rs
+            // .filter(|&version| version != ".global-version")
+            .find(|version| required_version.matches(version))
+            .cloned()
+    }
+
+    /// Given a Solidity file, it detects the latest compiler version which can be used
+    /// to build it, and returns it along with its canonicalized path. If the required
+    /// compiler version is not installed, it also proceeds to install it.
+    fn detect_version(&mut self, fname: PathBuf) -> Result<Option<(Version, String)>> {
+        let path = std::fs::canonicalize(&fname)?;
+
+        // detects the required solc version
+        let sol_version = Self::version_req(&path)?;
+
+        let path_str = path
+            .into_os_string()
+            .into_string()
+            .map_err(|_| eyre::eyre!("invalid path, maybe not utf-8?"))?;
+
+        // use the installed one, install it if it does not exist
+        let res = self
+            .find_matching_installation(&self.versions, &sol_version)
+            .or_else(|| {
+                // Check upstream for a matching install
+                self.find_matching_installation(&self.releases, &sol_version)
+                    .map(|version| {
+                        println!("Installing {}", version);
+                        // Blocking call to install it over RPC.
+                        tokio::runtime::Runtime::new()
+                            .unwrap()
+                            .block_on(svm::install(&version))
+                            .unwrap();
+                        self.versions.push(version.clone());
+                        println!("Done!");
+                        version
+                    })
+            })
+            .map(|version| (version, path_str));
+
+        Ok(res)
+    }
+
+    /// Builds all provided contract files with the specified compiler version.
+    /// Assumes that the lib-paths and remappings have already been specified.
+    pub fn build(
+        &self,
+        version: String,
+        files: Vec<String>,
+    ) -> Result<HashMap<String, CompiledContract>> {
+        let mut compiler_path = installed_version_paths()?
+            .iter()
+            .find(|name| name.to_string_lossy().contains(&version))
+            .unwrap()
+            .clone();
+        compiler_path.push(format!("solc-{}", &version));
+
+        let mut solc = Solc::new_with_paths(files).solc_path(compiler_path);
+        let lib_paths = self
+            .lib_paths
+            .iter()
+            .filter(|path| PathBuf::from(path).exists())
+            .map(|path| {
+                std::fs::canonicalize(path)
+                    .unwrap()
+                    .into_os_string()
+                    .into_string()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        solc = solc.args(["--allow-paths", &lib_paths]);
+
+        if !self.remappings.is_empty() {
+            solc = solc.args(self.remappings)
+        }
+
+        Ok(solc.build()?)
+    }
+
+    /// Builds all contracts with their corresponding compiler versions
+    pub fn build_all(&mut self) -> Result<HashMap<String, CompiledContract>> {
+        let contracts_by_version = self.contract_versions()?;
+        contracts_by_version
+            .into_iter()
+            .try_fold(HashMap::new(), |mut map, (version, files)| {
+                let res = self.build(version, files)?;
+                map.extend(res);
+                Ok::<_, eyre::Error>(map)
+            })
+    }
 }
 
 impl<'a> MultiContractRunner<'a> {
@@ -316,114 +482,7 @@ impl<'a> MultiContractRunner<'a> {
             let out_file = std::fs::read_to_string(out_path)?;
             serde_json::from_str::<DapptoolsArtifact>(&out_file)?.contracts()?
         } else {
-            // Group contracts in the nones with the same version pragma
-            let files = glob::glob(contracts)?;
-
-            let mut contracts_by_version = HashMap::new();
-            let versions = svm::installed_versions()?;
-            let releases = tokio::runtime::Runtime::new()?.block_on(svm::all_versions())?;
-            for fname in files {
-                let path = std::fs::canonicalize(fname?)
-                    .unwrap()
-                    .into_os_string()
-                    .into_string()
-                    .unwrap();
-                use std::fs::File;
-                use std::io::{BufRead, BufReader};
-
-                // parse the version from the contract
-                let sol_version = {
-                    use semver::VersionReq;
-                    let file = BufReader::new(File::open(&path)?);
-                    let version = file
-                        .lines()
-                        .map(|line| line.unwrap())
-                        .find(|line| line.starts_with("pragma"))
-                        .ok_or_else(|| eyre::eyre!("{} has no version", path))?;
-                    let version = version
-                        .replace("pragma solidity ", "")
-                        .replace(";", "")
-                        // needed to make it valid semver
-                        .replace(" ", ",");
-
-                    VersionReq::parse(&version)?
-                };
-
-                let mut found_version = None;
-                for version in &versions {
-                    if version == ".global-version" {
-                        continue;
-                    }
-                    if sol_version.matches(&version.parse().unwrap()) {
-                        found_version = Some(version.clone());
-                    }
-                }
-
-                // if we don't have the version, we'll try to install it from the
-                // available releases
-                if found_version.is_none() {
-                    let mut upstream_version = None;
-                    for version in &releases {
-                        if version == ".global-version" {
-                            continue;
-                        }
-                        if sol_version.matches(&version.parse().unwrap()) {
-                            upstream_version = Some(version.clone());
-                        }
-                    }
-
-                    // TODO: This blocks the thread, we obviously do not want that
-                    if let Some(upstream_version) = upstream_version {
-                        println!("Installing {}", upstream_version);
-                        tokio::runtime::Runtime::new()?
-                            .block_on(svm::install(&upstream_version))?;
-                        println!("Done!");
-                        found_version = Some(upstream_version);
-                    }
-                }
-
-                // we found a version
-                if let Some(found_version) = found_version {
-                    let entry = contracts_by_version.entry(found_version).or_insert(vec![]);
-                    entry.push(path);
-                }
-            }
-
-            let mut res = HashMap::new();
-            let paths = installed_version_paths()?;
-            for (version, files) in contracts_by_version {
-                // override the version for the loop
-                svm::use_version(&version)?;
-
-                let mut compiler_path = paths
-                    .iter()
-                    .find(|name| name.to_string_lossy().contains(&version))
-                    .unwrap()
-                    .clone();
-                compiler_path.push(format!("solc-{}", &version));
-
-                let mut solc = Solc::new_with_paths(files).solc_path(compiler_path);
-                let lib_paths = lib_paths
-                    .iter()
-                    .filter(|path| !path.is_empty())
-                    .map(|path| {
-                        std::fs::canonicalize(path)
-                            .unwrap()
-                            .into_os_string()
-                            .into_string()
-                            .unwrap()
-                    })
-                    .collect::<Vec<_>>()
-                    .join(",");
-                solc = solc.args(["--allow-paths", &lib_paths]);
-
-                if !remappings.is_empty() {
-                    solc = solc.args(&remappings)
-                }
-                res.extend(solc.build()?);
-            }
-
-            res
+            SolcBuilder::new(contracts, &remappings, &lib_paths)?.build_all()?
         })
     }
 


### PR DESCRIPTION
* if a version is not detected locally and is in your contracts, it automatically gets downloaded for you
* it groups contracts by compiler and proceeds to execute them all together