### PR TITLE
Inform users to update in case of error [E0658]

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ cargo test
 cargo doc --open
 cargo build [--release]
 ```
+**Tip**: If you encounter the following error when building the project, please update your Rust toolchain with `rustup update`.
+
+```
+error[E0658]: use of unstable library feature 'map_into_keys_values'
+```
 
 ### CLI Help
 


### PR DESCRIPTION
If users try to build/check the project with an older version of rust, it will fail due to this error: `error[E0658]: use of unstable library feature 'map_into_keys_values'`.

It is fixed with `rustup update`