### PR TITLE
feat: ens & balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ ARGS:
     * [x] `block`
     * [x] `call` (partial)
     * [x] `send` (partial)
+    * [x] `balance`
+    * [x] `ens`
 * dapp
     * [ ] test
         * [x] simple unit tests
@@ -216,7 +218,7 @@ ARGS:
         * [ ] structured tracing with abi decoding
         * [ ] per-line gas profiling
         * [ ] forking mode
-        * [ ] automatic solc selection
+        * [x] automatic solc selection
     * [x] build
         * [x] can read DappTools-style .sol.json artifacts
         * [x] remappings

--- a/seth/src/lib.rs
+++ b/seth/src/lib.rs
@@ -56,7 +56,12 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn call(&self, to: Address, sig: &str, args: Vec<String>) -> Result<String> {
+    pub async fn call<T: Into<NameOrAddress>>(
+        &self,
+        to: T,
+        sig: &str,
+        args: Vec<String>,
+    ) -> Result<String> {
         let func = get_func(sig)?;
         let data = encode_args(&func, &args)?;
 
@@ -96,12 +101,17 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn send(
+    pub async fn send<F: Into<NameOrAddress>, T: Into<NameOrAddress>>(
         &self,
-        from: Address,
-        to: Address,
+        from: F,
+        to: T,
         args: Option<(&str, Vec<String>)>,
     ) -> Result<PendingTransaction<'_, M::Provider>> {
+        let from = match from.into() {
+            NameOrAddress::Name(ref ens_name) => self.provider.resolve_name(ens_name).await?,
+            NameOrAddress::Address(addr) => addr,
+        };
+
         // make the call
         let mut tx = Eip1559TransactionRequest::new().from(from).to(to);
 

--- a/seth/src/lib.rs
+++ b/seth/src/lib.rs
@@ -82,6 +82,14 @@ where
         Ok(s)
     }
 
+    pub async fn balance<T: Into<NameOrAddress> + Send + Sync>(
+        &self,
+        who: T,
+        block: Option<BlockId>,
+    ) -> Result<U256> {
+        Ok(self.provider.get_balance(who, block).await?)
+    }
+
     /// Sends a transaction to the specified address
     ///
     /// ```no_run


### PR DESCRIPTION
Adds support for
* `seth resolve-name`
* `seth lookup-address`
* `seth balance`

Makes `seth call`, `seth balance` and `seth send` accept ENS names (they auto-resolve them internally).

Finally, makes the singleton commands work with `stdin` so that they compose, e.g. you can do `seth 