### PR TITLE
test: share compilation step to avoid race condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#a6918aed2b0081837c6ef9af56d14fc4d59beae6"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#566f4c1f34d9d049b172a28747926b6099b1544f"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#a6918aed2b0081837c6ef9af56d14fc4d59beae6"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#566f4c1f34d9d049b172a28747926b6099b1544f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#a6918aed2b0081837c6ef9af56d14fc4d59beae6"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#566f4c1f34d9d049b172a28747926b6099b1544f"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#a6918aed2b0081837c6ef9af56d14fc4d59beae6"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#566f4c1f34d9d049b172a28747926b6099b1544f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.5.2"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#a6918aed2b0081837c6ef9af56d14fc4d59beae6"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#566f4c1f34d9d049b172a28747926b6099b1544f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#a6918aed2b0081837c6ef9af56d14fc4d59beae6"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#566f4c1f34d9d049b172a28747926b6099b1544f"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.5.2"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#a6918aed2b0081837c6ef9af56d14fc4d59beae6"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#566f4c1f34d9d049b172a28747926b6099b1544f"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#a6918aed2b0081837c6ef9af56d14fc4d59beae6"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#566f4c1f34d9d049b172a28747926b6099b1544f"
 dependencies = [
  "async-trait",
  "coins-bip32",

--- a/dapp/src/lib.rs
+++ b/dapp/src/lib.rs
@@ -586,16 +586,19 @@ impl<'a> MultiContractRunner<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ethers::utils::id;
+    use ethers::{prelude::Lazy, utils::id};
+
+    static COMPILED: Lazy<HashMap<String, CompiledContract>> = Lazy::new(|| {
+        SolcBuilder::new("./*.sol", &[], &[])
+            .unwrap()
+            .build_all()
+            .unwrap()
+    });
 
     #[test]
     fn can_call_vm_directly() {
         let cfg = Config::istanbul();
-        let compiled = SolcBuilder::new("./*.sol", &[], &[])
-            .unwrap()
-            .build_all()
-            .unwrap();
-        let compiled = compiled.get("Greeter").expect("could not find contract");
+        let compiled = COMPILED.get("Greeter").expect("could not find contract");
 
         let addr = "0x1000000000000000000000000000000000000000"
             .parse()
@@ -634,11 +637,7 @@ mod tests {
     fn solidity_unit_test() {
         let cfg = Config::istanbul();
 
-        let compiled = SolcBuilder::new("./*.sol", &[], &[])
-            .unwrap()
-            .build_all()
-            .unwrap();
-        let compiled = compiled
+        let compiled = COMPILED
             .get("GreeterTest")
             .expect("could not find contract");
 
@@ -679,11 +678,7 @@ mod tests {
     fn failing_with_no_reason_if_no_setup() {
         let cfg = Config::istanbul();
 
-        let compiled = SolcBuilder::new("./*.sol", &[], &[])
-            .unwrap()
-            .build_all()
-            .unwrap();
-        let compiled = compiled
+        let compiled = COMPILED
             .get("GreeterTest")
             .expect("could not find contract");
 
@@ -712,11 +707,7 @@ mod tests {
     fn failing_solidity_unit_test() {
         let cfg = Config::istanbul();
 
-        let compiled = SolcBuilder::new("./*.sol", &[], &[])
-            .unwrap()
-            .build_all()
-            .unwrap();
-        let compiled = compiled
+        let compiled = COMPILED
             .get("GreeterTest")
             .expect("could not find contract");
 
@@ -758,11 +749,7 @@ mod tests {
     fn test_runner() {
         let cfg = Config::istanbul();
 
-        let compiled = SolcBuilder::new("./*.sol", &[], &[])
-            .unwrap()
-            .build_all()
-            .unwrap();
-        let compiled = compiled
+        let compiled = COMPILED
             .get("GreeterTest")
             .expect("could not find contract");
 


### PR DESCRIPTION
There seems to be a race condition the first time the compilers are installed which makes later running the compilation step fail with:

```
Installing 0.7.6
Done!
thread 'tests::failing_solidity_unit_test' panicked at '`"/home/runner/.svm/0.7.6/solc-0.7.6"` not found', /home/runner/.cargo/git/checkouts/ethers-rs-c3a7c0a0ae0fe6be/64294d1/ethers-core/src/utils/solc.rs:240:33
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is fixed by running the compilation step _once_ and then re-using the value across tests.

I wonder why this is happening. Possibly due to some overwrite inside [install](https://github.com/roynalnaruto/svm-rs/blob/master/src/lib.rs#L96) when called multiple times in parallel?