### PR TITLE
Fix docs generation for libraries

### DIFF
--- a/dapptools/Cargo.toml
+++ b/dapptools/Cargo.toml
@@ -25,7 +25,9 @@ tracing-subscriber = "0.2.20"
 [[bin]]
 name = "seth"
 path = "src/seth.rs"
+doc = false
 
 [[bin]]
 name = "dapp"
 path = "src/dapp.rs"
+doc = false


### PR DESCRIPTION
Noticed that the docs for the libraries were getting overwritten by the less useful docs for the binaries.