### PR TITLE
feat: forked rpc provider for SputnikEVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,6 +1032,7 @@ dependencies = [
  "evmodin",
  "eyre",
  "once_cell",
+ "tokio",
  "tracing",
 ]
 

--- a/ForkTest.sol
+++ b/ForkTest.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.1;
+
+// cargo r --bin dapp test --contracts './ForkTest.sol' --fork-url <your url> --fork-block-number 13292582
+contract ForkTest {
+    // only passes at block https://etherscan.io/block/13292582
+    function testBal() public {
+        require(address(0x1aD91ee08f21bE3dE0BA2ba6918E714dA6B45836).balance == 5535797434271969477039);
+    }
+}

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -40,6 +40,17 @@ pub enum Subcommands {
 
         #[structopt(help = "skip re-compilation", long, short)]
         no_compile: bool,
+
+        #[structopt(
+            help = "fetch state over a remote instead of starting from empty state",
+            long,
+            short
+        )]
+        #[structopt(alias = "--rpc-url")]
+        fork_url: Option<String>,
+
+        #[structopt(help = "pins the block number for the state fork", long)]
+        fork_block_number: Option<u64>,
     },
     Build {
         #[structopt(flatten)]

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -46,7 +46,7 @@ pub enum Subcommands {
             long,
             short
         )]
-        #[structopt(alias = "--rpc-url")]
+        #[structopt(alias = "rpc-url")]
         fork_url: Option<String>,
 
         #[structopt(help = "pins the block number for the state fork", long)]

--- a/evm-adapters/Cargo.toml
+++ b/evm-adapters/Cargo.toml
@@ -21,6 +21,7 @@ eyre = "0.6.5"
 once_cell = "1.8.0"
 tracing = "0.1.28"
 bytes = "1.1.0"
+tokio = { version = "1.12.0", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 evmodin = { git = "https://github.com/vorot93/evmodin", features = ["util"] }

--- a/evm-adapters/src/blocking_provider.rs
+++ b/evm-adapters/src/blocking_provider.rs
@@ -1,0 +1,76 @@
+use ethers::{
+    providers::Middleware,
+    types::{Address, BlockId, Bytes, H256, U256},
+};
+use tokio::runtime::Runtime;
+
+#[derive(Debug)]
+/// Blocking wrapper around an Ethers middleware, for use in synchronous contexts
+/// (powered by a tokio runtime)
+pub struct BlockingProvider<M> {
+    provider: M,
+    runtime: Runtime,
+}
+
+#[cfg(feature = "sputnik")]
+use sputnik::backend::MemoryVicinity;
+
+impl<M: Middleware> BlockingProvider<M> {
+    pub fn new(provider: M) -> Self {
+        Self { provider, runtime: Runtime::new().unwrap() }
+    }
+
+    #[cfg(feature = "sputnik")]
+    pub fn vicinity(&self, pin_block: Option<u64>) -> Result<MemoryVicinity, M::Error> {
+        let block_number = if let Some(pin_block) = pin_block {
+            pin_block
+        } else {
+            self.block_on(self.provider.get_block_number())?.as_u64()
+        };
+
+        let gas_price = self.block_on(self.provider.get_gas_price())?;
+        let chain_id = self.block_on(self.provider.get_chainid())?;
+        let block = self.block_on(self.provider.get_block(block_number))?.expect("block not found");
+
+        Ok(MemoryVicinity {
+            origin: Address::default(),
+            chain_id,
+            block_hashes: Vec::new(),
+            block_number: block.number.expect("block number not found").as_u64().into(),
+            block_coinbase: block.author,
+            block_difficulty: block.difficulty,
+            block_gas_limit: block.gas_limit,
+            block_timestamp: block.timestamp,
+            gas_price,
+        })
+    }
+
+    fn block_on<F: std::future::Future>(&self, f: F) -> F::Output {
+        self.runtime.block_on(f)
+    }
+
+    pub fn get_balance(&self, address: Address, block: Option<BlockId>) -> Result<U256, M::Error> {
+        self.block_on(self.provider.get_balance(address, block))
+    }
+
+    pub fn get_transaction_count(
+        &self,
+        address: Address,
+        block: Option<BlockId>,
+    ) -> Result<U256, M::Error> {
+        self.block_on(self.provider.get_transaction_count(address, block))
+    }
+
+    pub fn get_code(&self, address: Address, block: Option<BlockId>) -> Result<Bytes, M::Error> {
+        self.block_on(self.provider.get_code(address, block))
+    }
+
+    pub fn get_storage_at(
+        &self,
+        address: Address,
+        slot: H256,
+        block: Option<BlockId>,
+    ) -> Result<H256, M::Error> {
+        self.block_on(self.provider.get_storage_at(address, slot, block))
+    }
+}

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -6,6 +6,9 @@ pub mod sputnik;
 #[cfg(feature = "evmodin")]
 pub mod evmodin;
 
+mod blocking_provider;
+pub use blocking_provider::BlockingProvider;
+
 use ethers::{
     abi::{Detokenize, Function, Tokenize},
     core::types::{Address, U256},

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -237,3 +237,4 @@ mod tests {
         assert_eq!(reason, "not equal to `hi`");
     }
 }
+

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -7,7 +7,7 @@ use ethers::{
 };
 
 use sputnik::{
-    backend::{MemoryAccount, MemoryBackend},
+    backend::{Backend, MemoryAccount},
     executor::{MemoryStackState, StackExecutor, StackState, StackSubstateMetadata},
     Config, ExitReason, Handler,
 };
@@ -25,14 +25,10 @@ pub struct Executor<'a, S> {
 }
 
 // Concrete implementation over the in-memory backend
-impl<'a> Executor<'a, MemoryStackState<'a, 'a, MemoryBackend<'a>>> {
+impl<'a, B: Backend> Executor<'a, MemoryStackState<'a, 'a, B>> {
     /// Given a gas limit, vm version, initial chain configuration and initial state
     // TOOD: See if we can make lifetimes better here
-    pub fn new(
-        gas_limit: u64,
-        config: &'a Config,
-        backend: &'a MemoryBackend<'a>,
-    ) -> Executor<'a, MemoryStackState<'a, 'a, MemoryBackend<'a>>> {
+    pub fn new(gas_limit: u64, config: &'a Config, backend: &'a B) -> Self {
         // setup gasometer
         let metadata = StackSubstateMetadata::new(gas_limit, config);
         // setup state
@@ -237,4 +233,3 @@ mod tests {
         assert_eq!(reason, "not equal to `hi`");
     }
 }
-

--- a/evm-adapters/src/sputnik/forked_backend.rs
+++ b/evm-adapters/src/sputnik/forked_backend.rs
@@ -26,11 +26,8 @@ pub struct ForkMemoryBackend<M> {
 impl<M: Middleware> ForkMemoryBackend<M> {
     /// Create a new memory backend given a provider, an optional block to pin state
     /// against and a state tree
-    pub fn new(
-        provider: BlockingProvider<M>,
-        pin_block: Option<u64>,
-        state: BTreeMap<H160, MemoryAccount>,
-    ) -> Self {
+    pub fn new(provider: M, pin_block: Option<u64>, state: BTreeMap<H160, MemoryAccount>) -> Self {
+        let provider = BlockingProvider::new(provider);
         let vicinity = provider
             .vicinity(pin_block)
             .expect("could not instantiate vicinity corresponding to upstream");
@@ -191,7 +188,6 @@ mod tests {
             "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27",
         )
         .unwrap();
-        let provider = BlockingProvider::new(provider);
         let backend = ForkMemoryBackend::new(provider, Some(13292465), Default::default());
         let mut evm = Executor::new(12_000_000, &cfg, &backend);
         evm.initialize_contracts(vec![(addr, compiled.runtime_bytecode.clone())]);

--- a/evm-adapters/src/sputnik/forked_backend.rs
+++ b/evm-adapters/src/sputnik/forked_backend.rs
@@ -1,0 +1,214 @@
+use crate::BlockingProvider;
+
+use sputnik::backend::{Backend, Basic, MemoryAccount, MemoryVicinity};
+
+use ethers::{
+    providers::Middleware,
+    types::{H160, H256, U256},
+};
+use std::collections::BTreeMap;
+
+/// Memory backend with ability to fork another chain from an HTTP provider, storing all state
+/// values in a `BTreeMap` in memory.
+#[derive(Debug)]
+// TODO: Add option to easily 1. impersonate accounts, 2. roll back to pinned block
+pub struct ForkMemoryBackend<M> {
+    /// ethers middleware for querying on-chain data
+    pub provider: BlockingProvider<M>,
+    /// the global context of the chain
+    pub vicinity: MemoryVicinity,
+    /// state cache
+    // TODO: This should probably be abstracted away into something that efficiently
+    // also caches at disk etc.
+    pub state: BTreeMap<H160, MemoryAccount>,
+}
+
+impl<M: Middleware> ForkMemoryBackend<M> {
+    /// Create a new memory backend given a provider, an optional block to pin state
+    /// against and a state tree
+    pub fn new(
+        provider: BlockingProvider<M>,
+        pin_block: Option<u64>,
+        state: BTreeMap<H160, MemoryAccount>,
+    ) -> Self {
+        let vicinity = provider
+            .vicinity(pin_block)
+            .expect("could not instantiate vicinity corresponding to upstream");
+        Self { provider, vicinity, state }
+    }
+}
+
+impl<M: Middleware> Backend for ForkMemoryBackend<M> {
+    fn gas_price(&self) -> U256 {
+        self.vicinity.gas_price
+    }
+
+    fn origin(&self) -> H160 {
+        self.vicinity.origin
+    }
+
+    fn block_hash(&self, number: U256) -> H256 {
+        if number >= self.vicinity.block_number ||
+            self.vicinity.block_number - number - U256::one() >=
+                U256::from(self.vicinity.block_hashes.len())
+        {
+            H256::default()
+        } else {
+            let index = (self.vicinity.block_number - number - U256::one()).as_usize();
+            self.vicinity.block_hashes[index]
+        }
+    }
+
+    fn block_number(&self) -> U256 {
+        self.vicinity.block_number
+    }
+
+    fn block_coinbase(&self) -> H160 {
+        self.vicinity.block_coinbase
+    }
+
+    fn block_timestamp(&self) -> U256 {
+        self.vicinity.block_timestamp
+    }
+
+    fn block_difficulty(&self) -> U256 {
+        self.vicinity.block_difficulty
+    }
+
+    fn block_gas_limit(&self) -> U256 {
+        self.vicinity.block_gas_limit
+    }
+
+    fn chain_id(&self) -> U256 {
+        self.vicinity.chain_id
+    }
+
+    fn exists(&self, address: H160) -> bool {
+        let mut exists = self.state.contains_key(&address);
+
+        // check non-zero balance
+        if !exists {
+            let balance = self
+                .provider
+                .get_balance(address, Some(self.vicinity.block_number.as_u64().into()))
+                .unwrap_or_default();
+            exists = balance != U256::zero();
+        }
+
+        // check non-zero nonce
+        if !exists {
+            let nonce = self
+                .provider
+                .get_transaction_count(address, Some(self.vicinity.block_number.as_u64().into()))
+                .unwrap_or_default();
+            exists = nonce != U256::zero();
+        }
+
+        // check non-empty code
+        if !exists {
+            let code = self
+                .provider
+                .get_code(address, Some(self.vicinity.block_number.as_u64().into()))
+                .unwrap_or_default();
+            exists = !code.0.is_empty();
+        }
+
+        exists
+    }
+
+    fn basic(&self, address: H160) -> Basic {
+        self.state
+            .get(&address)
+            .map(|a| Basic { balance: a.balance, nonce: a.nonce })
+            .unwrap_or_else(|| Basic {
+                balance: self
+                    .provider
+                    .get_balance(address, Some(self.vicinity.block_number.as_u64().into()))
+                    .unwrap_or_default(),
+                nonce: self
+                    .provider
+                    .get_transaction_count(
+                        address,
+                        Some(self.vicinity.block_number.as_u64().into()),
+                    )
+                    .unwrap_or_default(),
+            })
+    }
+
+    fn code(&self, address: H160) -> Vec<u8> {
+        self.state.get(&address).map(|v| v.code.clone()).unwrap_or_else(|| {
+            self.provider
+                .get_code(address, Some(self.vicinity.block_number.as_u64().into()))
+                .unwrap_or_default()
+                .to_vec()
+        })
+    }
+
+    fn storage(&self, address: H160, index: H256) -> H256 {
+        if let Some(acct) = self.state.get(&address) {
+            if let Some(store_data) = acct.storage.get(&index) {
+                *store_data
+            } else {
+                self.provider
+                    .get_storage_at(
+                        address,
+                        index,
+                        Some(self.vicinity.block_number.as_u64().into()),
+                    )
+                    .unwrap_or_default()
+            }
+        } else {
+            self.provider
+                .get_storage_at(address, index, Some(self.vicinity.block_number.as_u64().into()))
+                .unwrap_or_default()
+        }
+    }
+
+    fn original_storage(&self, address: H160, index: H256) -> Option<H256> {
+        Some(self.storage(address, index))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{sputnik::Executor, test_helpers::COMPILED, Evm};
+    use ethers::{
+        providers::{Http, Provider},
+        types::Address,
+    };
+    use sputnik::Config;
+    use std::convert::TryFrom;
+
+    use super::*;
+
+    #[test]
+    fn forked_backend() {
+        let cfg = Config::istanbul();
+        let compiled = COMPILED.get("Greeter").expect("could not find contract");
+        let addr = "0x1000000000000000000000000000000000000000".parse().unwrap();
+
+        let provider = Provider::<Http>::try_from(
+            "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27",
+        )
+        .unwrap();
+        let provider = BlockingProvider::new(provider);
+        let backend = ForkMemoryBackend::new(provider, Some(13292465), Default::default());
+        let mut evm = Executor::new(12_000_000, &cfg, &backend);
+        evm.initialize_contracts(vec![(addr, compiled.runtime_bytecode.clone())]);
+
+        // call the setup function to deploy the contracts inside the test
+
+        let (res, _, _) = evm
+            .call::<U256, _>(
+                Address::zero(),
+                addr,
+                &dapp_utils::get_func("function time() public view returns (uint256)").unwrap(),
+                (),
+                0.into(),
+            )
+            .unwrap();
+
+        // https://etherscan.io/block/13292465
+        assert_eq!(res.as_u64(), 1632539668);
+    }
+}

--- a/evm-adapters/src/sputnik/mod.rs
+++ b/evm-adapters/src/sputnik/mod.rs
@@ -1,3 +1,5 @@
-mod forked_backend;
 mod evm;
 pub use evm::*;
+
+mod forked_backend;
+pub use forked_backend::ForkMemoryBackend;

--- a/evm-adapters/src/sputnik/mod.rs
+++ b/evm-adapters/src/sputnik/mod.rs
@@ -1,0 +1,3 @@
+mod forked_backend;
+mod evm;
+pub use evm::*;

--- a/evm-adapters/testdata/GreetTest.sol
+++ b/evm-adapters/testdata/GreetTest.sol
@@ -8,6 +8,10 @@ contract Greeter {
         greeting = _greeting;
     }
 
+    function time() public view returns (uint256) {
+        return block.timestamp;
+    }
+
     function gm() public {
         greeting = "gm";
     }


### PR DESCRIPTION
Allows sputnik to fork state over RPC via any ethers-rs compatible `Middleware`. This means we can run our tests against mainnet / testnet state!

Follow-up work should generalize the provider to instead be possible to work w/ Geth's leveldb etc. This'd work by first extracting the `BlockingProvider`'s calls to a trait, and then implementing that trait.

The CLI allows passing in fork params as below:

```
cargo r --bin dapp test --contracts './ForkTest.sol' --fork-url https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27 --fork-block-number 13292582               
```

Forking code modified from @brockelmore's https://github.com/brockelmore/rust-cevm/blob/35cdefb760d41197ccfadc8c446343f20eba9080/src/backend/fork_memory_owned.rs

Part of #25 