### PR TITLE
feat: fuzzing 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +565,7 @@ dependencies = [
  "eyre",
  "glob",
  "hex",
+ "proptest",
  "regex",
  "semver 1.0.4",
  "serde",
@@ -2153,6 +2169,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2257,15 @@ name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
 ]
@@ -2397,6 +2454,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -3295,6 +3364,15 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.30.1"
-source = "git+https://github.com/gakonst/evm#5c338f1d6e412b7b0304481a23cc7517682a2f25"
+source = "git+https://github.com/gakonst/evm?branch=feat/clone-debug#33a3d5288e8a105c7d1e2b5385937e1d96e6f678"
 dependencies = [
  "environmental",
  "ethereum",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm#5c338f1d6e412b7b0304481a23cc7517682a2f25"
+source = "git+https://github.com/gakonst/evm?branch=feat/clone-debug#33a3d5288e8a105c7d1e2b5385937e1d96e6f678"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -1066,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm#5c338f1d6e412b7b0304481a23cc7517682a2f25"
+source = "git+https://github.com/gakonst/evm?branch=feat/clone-debug#33a3d5288e8a105c7d1e2b5385937e1d96e6f678"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm#5c338f1d6e412b7b0304481a23cc7517682a2f25"
+source = "git+https://github.com/gakonst/evm?branch=feat/clone-debug#33a3d5288e8a105c7d1e2b5385937e1d96e6f678"
 dependencies = [
  "environmental",
  "evm-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "evm-adapters",
  "evmodin",
  "eyre",
+ "proptest",
  "regex",
  "rpassword",
  "rustc-hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "evmodin"
 version = "0.1.0"
-source = "git+https://github.com/vorot93/evmodin#ef1bee33aeee962421e32bf23cfb0bb4903a3125"
+source = "git+https://github.com/gakonst/evmodin?branch=feat/clone-debug#15a35271f4e7fda41d88cc78216d4900ea03bace"
 dependencies = [
  "arrayvec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ panic = "abort"
 
 [patch."https://github.com/rust-blockchain/evm"]
 evm = { git = "https://github.com/gakonst/evm", branch = "feat/clone-debug" }
+
+[patch."https://github.com/vorot93/evmodin"]
+evmodin = { git = "https://github.com/gakonst/evmodin", branch = "feat/clone-debug" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 panic = "abort"
+
+[patch."https://github.com/rust-blockchain/evm"]
+evm = { git = "https://github.com/gakonst/evm", branch = "feat/clone-debug" }

--- a/dapp/Cargo.toml
+++ b/dapp/Cargo.toml
@@ -26,6 +26,7 @@ glob = "0.3.0"
 tokio = { version = "1.10.1" }
 tracing = "0.1.26"
 tracing-subscriber = "0.2.20"
+proptest = "1.0.0"
 
 [dev-dependencies]
 evm-adapters = { path = "./../evm-adapters", features = ["sputnik", "sputnik-helpers", "evmodin", "evmodin-helpers"] }

--- a/dapp/Cargo.toml
+++ b/dapp/Cargo.toml
@@ -32,4 +32,4 @@ proptest = "1.0.0"
 evm-adapters = { path = "./../evm-adapters", features = ["sputnik", "sputnik-helpers", "evmodin", "evmodin-helpers"] }
 evmodin = { git = "https://github.com/vorot93/evmodin", features = ["util"] }
 # evm = { version = "0.30.1" }
-evm = { git = "https://github.com/gakonst/evm" }
+evm = { git = "https://github.com/rust-blockchain/evm" }

--- a/dapp/GreetTest.sol
+++ b/dapp/GreetTest.sol
@@ -35,6 +35,12 @@ contract GreeterTest is GreeterTestSetup {
         require(keccak256(abi.encodePacked(greeter.greeting())) == keccak256(abi.encodePacked(myGreeting)), "not equal");
     }
 
+    // TODO: Figure out what's the largest string length that we can fuzz for. This
+    // probably works better for non-variable sized types.
+    function testFuzzShrinking(string memory someString) public {
+        require(bytes(someString).length < 70, "too short");
+    }
+
     // check the positive case
     function testGreeting() public {
         greeter.greet("yo");

--- a/dapp/GreetTest.sol
+++ b/dapp/GreetTest.sol
@@ -35,10 +35,8 @@ contract GreeterTest is GreeterTestSetup {
         require(keccak256(abi.encodePacked(greeter.greeting())) == keccak256(abi.encodePacked(myGreeting)), "not equal");
     }
 
-    // TODO: Figure out what's the largest string length that we can fuzz for. This
-    // probably works better for non-variable sized types.
-    function testFuzzShrinking(string memory someString) public {
-        require(bytes(someString).length < 70, "too short");
+    function testFuzzShrinking(uint256 x, uint256 y) public {
+        require(x * y <= 100, "product greater than 100");
     }
 
     // check the positive case

--- a/dapp/GreetTest.sol
+++ b/dapp/GreetTest.sol
@@ -30,6 +30,11 @@ contract GreeterTest is GreeterTestSetup {
         greeter.greet(greeting);
     }
 
+    function testFuzzing(string memory myGreeting) public {
+        greeter.greet(myGreeting);
+        require(keccak256(abi.encodePacked(greeter.greeting())) == keccak256(abi.encodePacked(myGreeting)), "not equal");
+    }
+
     // check the positive case
     function testGreeting() public {
         greeter.greet("yo");

--- a/dapp/src/fuzz.rs
+++ b/dapp/src/fuzz.rs
@@ -1,0 +1,27 @@
+use ethers::{
+    abi::{Function, ParamType, Token, Tokenizable},
+    types::{Address, Bytes},
+};
+
+use proptest::prelude::*;
+
+pub fn fuzz_calldata(func: &Function) -> impl Strategy<Value = Bytes> + '_ {
+    // We need to compose all the strategies generated for each parameter in all
+    // possible combinations
+    let strats = func.inputs.iter().map(|input| fuzz_param(&input.kind)).collect::<Vec<_>>();
+
+    strats.prop_map(move |tokens| func.encode_input(&tokens).unwrap().into())
+}
+
+fn fuzz_param(param: &ParamType) -> impl Strategy<Value = Token> {
+    match param {
+        ParamType::Address => {
+            // The key to making this work is the `boxed()` call which type erases everything
+            // https://altsysrq.github.io/proptest-book/proptest/tutorial/transforming-strategies.html
+            any::<[u8; 20]>().prop_map(|x| Address::from_slice(&x).into_token()).boxed()
+        }
+        ParamType::Bytes => any::<Vec<u8>>().prop_map(|x| Bytes::from(x).into_token()).boxed(),
+        // TODO: Implement the rest of the strategies
+        _ => unimplemented!(),
+    }
+}

--- a/dapp/src/fuzz.rs
+++ b/dapp/src/fuzz.rs
@@ -29,9 +29,7 @@ fn fuzz_param(param: &ParamType) -> impl Strategy<Value = Token> {
             17..=32 => any::<[u8; 32]>().prop_map(|x| U256::from(&x).into_token()).boxed(),
             _ => panic!("unsupported solidity type uint{}", n),
         },
-        ParamType::String => {
-            any::<String>().prop_map(|x| x.into_token()).boxed()
-        }
+        ParamType::String => any::<String>().prop_map(|x| x.into_token()).boxed(),
         ParamType::Bytes => any::<Vec<u8>>().prop_map(|x| Bytes::from(x).into_token()).boxed(),
         // TODO: Implement the rest of the strategies
         _ => unimplemented!(),

--- a/dapp/src/fuzz.rs
+++ b/dapp/src/fuzz.rs
@@ -1,6 +1,6 @@
 use ethers::{
     abi::{Function, ParamType, Token, Tokenizable},
-    types::{Address, Bytes},
+    types::{Address, Bytes, U256},
 };
 
 use proptest::prelude::*;
@@ -19,6 +19,18 @@ fn fuzz_param(param: &ParamType) -> impl Strategy<Value = Token> {
             // The key to making this work is the `boxed()` call which type erases everything
             // https://altsysrq.github.io/proptest-book/proptest/tutorial/transforming-strategies.html
             any::<[u8; 20]>().prop_map(|x| Address::from_slice(&x).into_token()).boxed()
+        }
+        ParamType::Uint(n) => match n / 8 {
+            1 => any::<u8>().prop_map(|x| x.into_token()).boxed(),
+            2 => any::<u16>().prop_map(|x| x.into_token()).boxed(),
+            3..=4 => any::<u32>().prop_map(|x| x.into_token()).boxed(),
+            5..=8 => any::<u64>().prop_map(|x| x.into_token()).boxed(),
+            9..=16 => any::<u128>().prop_map(|x| x.into_token()).boxed(),
+            17..=32 => any::<[u8; 32]>().prop_map(|x| U256::from(&x).into_token()).boxed(),
+            _ => panic!("unsupported solidity type uint{}", n),
+        },
+        ParamType::String => {
+            any::<String>().prop_map(|x| x.into_token()).boxed()
         }
         ParamType::Bytes => any::<Vec<u8>>().prop_map(|x| Bytes::from(x).into_token()).boxed(),
         // TODO: Implement the rest of the strategies

--- a/dapp/src/lib.rs
+++ b/dapp/src/lib.rs
@@ -7,6 +7,8 @@ pub use runner::{ContractRunner, TestResult};
 mod multi_runner;
 pub use multi_runner::{MultiContractRunner, MultiContractRunnerBuilder};
 
+mod fuzz;
+
 use ethers::abi;
 use eyre::Result;
 

--- a/dapp/src/multi_runner.rs
+++ b/dapp/src/multi_runner.rs
@@ -93,7 +93,7 @@ pub struct MultiContractRunner<E, S> {
 
 impl<E, S> MultiContractRunner<E, S>
 where
-    E: Evm<S>,
+    E: Evm<S> + Clone,
 {
     pub fn test(&mut self, pattern: Regex) -> Result<HashMap<String, HashMap<String, TestResult>>> {
         // NB: We also have access to the contract's abi. When running the test.
@@ -151,7 +151,7 @@ where
 mod tests {
     use super::*;
 
-    fn test_multi_runner<S, E: Evm<S>>(evm: E) {
+    fn test_multi_runner<S, E: Clone + Evm<S>>(evm: E) {
         let mut runner =
             MultiContractRunnerBuilder::default().contracts("./GreetTest.sol").build(evm).unwrap();
 
@@ -160,8 +160,8 @@ mod tests {
         // 2 contracts
         assert_eq!(results.len(), 2);
 
-        // 3 tests on greeter 1 on gm
-        assert_eq!(results["GreeterTest"].len(), 3);
+        // 4 tests (1 being a fuzztest) on greeter 1 on gm
+        assert_eq!(results["GreeterTest"].len(), 4);
         assert_eq!(results["GmTest"].len(), 1);
         for (_, res) in results {
             assert!(res.iter().all(|(_, result)| result.success));
@@ -172,7 +172,7 @@ mod tests {
         assert_eq!(only_gm["GmTest"].len(), 1);
     }
 
-    fn test_ds_test_fail<S, E: Evm<S>>(evm: E) {
+    fn test_ds_test_fail<S, E: Clone + Evm<S>>(evm: E) {
         let mut runner =
             MultiContractRunnerBuilder::default().contracts("./../FooTest.sol").build(evm).unwrap();
         let results = runner.test(Regex::new(".*").unwrap()).unwrap();

--- a/dapp/src/multi_runner.rs
+++ b/dapp/src/multi_runner.rs
@@ -7,6 +7,7 @@ use ethers::{
     utils::{keccak256, CompiledContract},
 };
 
+use proptest::test_runner::TestRunner;
 use regex::Regex;
 
 use eyre::Result;
@@ -24,12 +25,14 @@ pub struct MultiContractRunnerBuilder<'a> {
     /// The path for the output file
     pub out_path: PathBuf,
     pub no_compile: bool,
+    /// The fuzzer to be used for running fuzz tests
+    pub fuzzer: Option<TestRunner>,
 }
 
 impl<'a> MultiContractRunnerBuilder<'a> {
     /// Given an EVM, proceeds to return a runner which is able to execute all tests
     /// against that evm
-    pub fn build<E, S>(&self, mut evm: E) -> Result<MultiContractRunner<E, S>>
+    pub fn build<E, S>(self, mut evm: E) -> Result<MultiContractRunner<E, S>>
     where
         E: Evm<S>,
     {
@@ -52,11 +55,22 @@ impl<'a> MultiContractRunnerBuilder<'a> {
         });
         evm.initialize_contracts(init_state);
 
-        Ok(MultiContractRunner { contracts, addresses, evm, state: PhantomData })
+        Ok(MultiContractRunner {
+            contracts,
+            addresses,
+            evm,
+            state: PhantomData,
+            fuzzer: self.fuzzer,
+        })
     }
 
     pub fn contracts(mut self, contracts: &'a str) -> Self {
         self.contracts = contracts;
+        self
+    }
+
+    pub fn fuzzer(mut self, fuzzer: TestRunner) -> Self {
+        self.fuzzer = Some(fuzzer);
         self
     }
 
@@ -88,6 +102,7 @@ pub struct MultiContractRunner<E, S> {
     addresses: HashMap<String, Address>,
     /// The EVM instance used in the test runner
     evm: E,
+    fuzzer: Option<TestRunner>,
     state: PhantomData<S>,
 }
 
@@ -143,7 +158,7 @@ where
         pattern: &Regex,
     ) -> Result<HashMap<String, TestResult>> {
         let mut runner = ContractRunner::new(&mut self.evm, contract, address);
-        runner.run_tests(pattern)
+        runner.run_tests(pattern, self.fuzzer.as_mut())
     }
 }
 
@@ -152,8 +167,12 @@ mod tests {
     use super::*;
 
     fn test_multi_runner<S, E: Clone + Evm<S>>(evm: E) {
-        let mut runner =
-            MultiContractRunnerBuilder::default().contracts("./GreetTest.sol").build(evm).unwrap();
+        let fuzzer = TestRunner::default();
+        let mut runner = MultiContractRunnerBuilder::default()
+            .contracts("./GreetTest.sol")
+            .fuzzer(fuzzer)
+            .build(evm)
+            .unwrap();
 
         let results = runner.test(Regex::new(".*").unwrap()).unwrap();
 

--- a/dapp/src/multi_runner.rs
+++ b/dapp/src/multi_runner.rs
@@ -167,20 +167,16 @@ mod tests {
     use super::*;
 
     fn test_multi_runner<S, E: Clone + Evm<S>>(evm: E) {
-        let fuzzer = TestRunner::default();
-        let mut runner = MultiContractRunnerBuilder::default()
-            .contracts("./GreetTest.sol")
-            .fuzzer(fuzzer)
-            .build(evm)
-            .unwrap();
+        let mut runner =
+            MultiContractRunnerBuilder::default().contracts("./GreetTest.sol").build(evm).unwrap();
 
         let results = runner.test(Regex::new(".*").unwrap()).unwrap();
 
         // 2 contracts
         assert_eq!(results.len(), 2);
 
-        // 4 tests (1 being a fuzztest) on greeter 1 on gm
-        assert_eq!(results["GreeterTest"].len(), 4);
+        // 3 tests on greeter 1 on gm
+        assert_eq!(results["GreeterTest"].len(), 3);
         assert_eq!(results["GmTest"].len(), 1);
         for (_, res) in results {
             assert!(res.iter().all(|(_, result)| result.success));

--- a/dapp/src/runner.rs
+++ b/dapp/src/runner.rs
@@ -282,10 +282,7 @@ mod tests {
         let mut runner =
             ContractRunner { evm: &mut evm, contract: compiled, address: addr, state: PhantomData };
 
-        let mut fuzzer = TestRunner::default();
-        let fuzzer = Some(&mut fuzzer);
-
-        let res = runner.run_tests(&".*".parse().unwrap(), fuzzer).unwrap();
+        let res = runner.run_tests(&".*".parse().unwrap(), None).unwrap();
         assert!(res.len() > 0);
         assert!(res.iter().all(|(_, result)| result.success == true));
     }

--- a/dapptools/Cargo.toml
+++ b/dapptools/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.26"
 
 ## EVM Implementations
 # evm = { version = "0.30.1" }
-sputnik = { package = "evm", git = "https://github.com/gakonst/evm",  optional = true }
+sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  optional = true }
 evmodin = { git = "https://github.com/vorot93/evmodin", optional = true }
 
 [features]

--- a/dapptools/Cargo.toml
+++ b/dapptools/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1.26"
 # evm = { version = "0.30.1" }
 sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  optional = true }
 evmodin = { git = "https://github.com/vorot93/evmodin", optional = true }
+proptest = "1.0.0"
 
 [features]
 default = ["sputnik-evm", "evmodin-evm"]

--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -105,7 +105,7 @@ fn main() -> eyre::Result<()> {
     Ok(())
 }
 
-fn test<S, E: evm_adapters::Evm<S>>(
+fn test<S, E: Clone + evm_adapters::Evm<S>>(
     builder: MultiContractRunnerBuilder,
     evm: E,
     pattern: Regex,
@@ -134,7 +134,15 @@ fn test<S, E: evm_adapters::Evm<S>>(
                 } else {
                     Colour::Red.paint("[FAIL]")
                 };
-                println!("{} {} (gas: {})", status, name, result.gas_used);
+                println!(
+                    "{} {} (gas: {})",
+                    status,
+                    name,
+                    result
+                        .gas_used
+                        .map(|x| x.to_string())
+                        .unwrap_or_else(|| "[fuzztest]".to_string())
+                );
             }
         }
     }

--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -42,6 +42,7 @@ fn main() -> eyre::Result<()> {
                 .remappings(&remappings)
                 .libraries(&lib_paths)
                 .out_path(out_path)
+                .fuzzer(proptest::test_runner::TestRunner::default())
                 .skip_compilation(no_compile);
 
             // run the tests depending on the chosen EVM

--- a/evm-adapters/Cargo.toml
+++ b/evm-adapters/Cargo.toml
@@ -11,7 +11,7 @@ dapp-utils = { path = "./../utils" }
 dapp-solc = { path = "./../solc" }
 
 # evm = { version = "0.30.1" }
-sputnik = { package = "evm", git = "https://github.com/gakonst/evm",  optional = true }
+sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  optional = true }
 
 evmodin = { git = "https://github.com/vorot93/evmodin",  optional = true }
 

--- a/evm-adapters/src/blocking_provider.rs
+++ b/evm-adapters/src/blocking_provider.rs
@@ -12,6 +12,12 @@ pub struct BlockingProvider<M> {
     runtime: Runtime,
 }
 
+impl<M: Clone> Clone for BlockingProvider<M> {
+    fn clone(&self) -> Self {
+        Self { provider: self.provider.clone(), runtime: Runtime::new().unwrap() }
+    }
+}
+
 #[cfg(feature = "sputnik")]
 use sputnik::backend::MemoryVicinity;
 

--- a/evm-adapters/src/evmodin.rs
+++ b/evm-adapters/src/evmodin.rs
@@ -1,8 +1,6 @@
 use crate::Evm;
 
-use ethers::{
-    types::{Address, Bytes, U256},
-};
+use ethers::types::{Address, Bytes, U256};
 
 use evmodin::{tracing::Tracer, AnalyzedCode, CallKind, Host, Message, Revision, StatusCode};
 

--- a/evm-adapters/src/evmodin.rs
+++ b/evm-adapters/src/evmodin.rs
@@ -8,6 +8,7 @@ use eyre::Result;
 
 // TODO: Check if we can implement this as the base layer of an ethers-provider
 // Middleware stack instead of doing RPC calls.
+#[derive(Clone, Debug)]
 pub struct EvmOdin<S, T> {
     pub host: S,
     pub gas_limit: u64,

--- a/evm-adapters/src/evmodin.rs
+++ b/evm-adapters/src/evmodin.rs
@@ -1,8 +1,6 @@
 use crate::Evm;
 
 use ethers::{
-    abi::{Detokenize, Function, Tokenize},
-    prelude::{decode_function_data, encode_function_data},
     types::{Address, Bytes, U256},
 };
 
@@ -62,16 +60,14 @@ impl<S: HostExt, Tr: Tracer> Evm<S> for EvmOdin<S, Tr> {
     }
 
     /// Runs the selected function
-    fn call<D: Detokenize, T: Tokenize>(
+    fn call_raw(
         &mut self,
         from: Address,
         to: Address,
-        func: &Function,
-        args: T, // derive arbitrary for Tokenize?
+        calldata: Bytes,
         value: U256,
-    ) -> Result<(D, Self::ReturnReason, u64)> {
-        let calldata = encode_function_data(func, args)?;
-
+        is_static: bool,
+    ) -> Result<(Bytes, Self::ReturnReason, u64)> {
         // For the `func.constant` field usage
         #[allow(deprecated)]
         let message = Message {
@@ -83,11 +79,7 @@ impl<S: HostExt, Tr: Tracer> Evm<S> for EvmOdin<S, Tr> {
             input_data: calldata.0,
             value,
             gas: self.gas_limit as i64,
-            is_static: func.constant ||
-                matches!(
-                    func.state_mutability,
-                    ethers::abi::StateMutability::View | ethers::abi::StateMutability::Pure
-                ),
+            is_static,
         };
 
         // get the bytecode at the host
@@ -98,14 +90,11 @@ impl<S: HostExt, Tr: Tracer> Evm<S> for EvmOdin<S, Tr> {
         let output =
             bytecode.execute(&mut self.host, &mut self.tracer, None, message, self.revision);
 
-        // let gas = dapp_utils::remove_extra_costs(gas_before - gas_after, calldata.as_ref());
-
-        let retdata = decode_function_data(func, output.output_data, false)?;
-
         // TODO: Figure out gas accounting.
+        // let gas = dapp_utils::remove_extra_costs(gas_before - gas_after, calldata.as_ref());
         let gas = U256::from(0);
 
-        Ok((retdata, output.status_code, gas.as_u64()))
+        Ok((output.output_data.to_vec().into(), output.status_code, gas.as_u64()))
     }
 }
 

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -1,8 +1,6 @@
 use crate::Evm;
 
 use ethers::{
-    abi::{Detokenize, Function, Tokenize},
-    prelude::{decode_function_data, encode_function_data},
     types::{Address, Bytes, U256},
 };
 
@@ -78,16 +76,14 @@ where
     }
 
     /// Runs the selected function
-    fn call<D: Detokenize, T: Tokenize>(
+    fn call_raw(
         &mut self,
         from: Address,
         to: Address,
-        func: &Function,
-        args: T, // derive arbitrary for Tokenize?
+        calldata: Bytes,
         value: U256,
-    ) -> Result<(D, ExitReason, u64)> {
-        let calldata = encode_function_data(func, args)?;
-
+        _is_static: bool,
+    ) -> Result<(Bytes, ExitReason, u64)> {
         let gas_before = self.executor.gas_left();
 
         let (status, retdata) =
@@ -96,9 +92,7 @@ where
         let gas_after = self.executor.gas_left();
         let gas = dapp_utils::remove_extra_costs(gas_before - gas_after, calldata.as_ref());
 
-        let retdata = decode_function_data(func, retdata, false)?;
-
-        Ok((retdata, status, gas.as_u64()))
+        Ok((retdata.into(), status, gas.as_u64()))
     }
 }
 

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -1,8 +1,6 @@
 use crate::Evm;
 
-use ethers::{
-    types::{Address, Bytes, U256},
-};
+use ethers::types::{Address, Bytes, U256};
 
 use sputnik::{
     backend::{Backend, MemoryAccount},

--- a/evm-adapters/src/sputnik/forked_backend.rs
+++ b/evm-adapters/src/sputnik/forked_backend.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 
 /// Memory backend with ability to fork another chain from an HTTP provider, storing all state
 /// values in a `BTreeMap` in memory.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 // TODO: Add option to easily 1. impersonate accounts, 2. roll back to pinned block
 pub struct ForkMemoryBackend<M> {
     /// ethers middleware for querying on-chain data


### PR DESCRIPTION
Closes https://github.com/gakonst/dapptools-rs/issues/16

Introduces fuzzing of solidity test functions with >0 arguments, using the [`proptest`](https://github.com/AltSysrq/proptest) library.

This is done in 2 parts:
1. Defining the fuzzing rules in `fuzz.rs` which basically says "take in an ABI type and generate a fuzzing strategy for it" and then "combine all fuzzing strategies for a certain function to a strategy for fuzzing the function's calldata"
2. Changing `runner.rs` to execute proptest's `TestRunner` if >0 inputs are detected for the current function. 

A requirement of fuzzing was to make the EVM cloneable, since the TestRunner only accepts `Fn`s which cannot mutate their environment, meaning that we had to add a `Clone` restriction on it in the fuzzing-related code. 

(To facilitate that, we need https://github.com/rust-blockchain/evm/pull/61 for Sputnik and https://github.com/vorot93/evmodin/pull/9 for EvmOdin)

TODO: 
* Expand the types being fuzzed.
* See if we can remove the `Clone` requirement by using a factory, and splitting the fuzz tests to a separate function so we can run fuzz tests w/o tracing even when the EVM uses a tracer in non-fuzz tests