### PR TITLE
feat: drop Evm Clone restrictions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.30.1"
-source = "git+https://github.com/gakonst/evm?branch=feat/clone-debug#33a3d5288e8a105c7d1e2b5385937e1d96e6f678"
+source = "git+https://github.com/rust-blockchain/evm#5ecf36ce393380a89c6f1b09ef79f686fe043624"
 dependencies = [
  "environmental",
  "ethereum",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm?branch=feat/clone-debug#33a3d5288e8a105c7d1e2b5385937e1d96e6f678"
+source = "git+https://github.com/rust-blockchain/evm#5ecf36ce393380a89c6f1b09ef79f686fe043624"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm?branch=feat/clone-debug#33a3d5288e8a105c7d1e2b5385937e1d96e6f678"
+source = "git+https://github.com/rust-blockchain/evm#5ecf36ce393380a89c6f1b09ef79f686fe043624"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm?branch=feat/clone-debug#33a3d5288e8a105c7d1e2b5385937e1d96e6f678"
+source = "git+https://github.com/rust-blockchain/evm#5ecf36ce393380a89c6f1b09ef79f686fe043624"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1089,7 +1089,7 @@ dependencies = [
 [[package]]
 name = "evmodin"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/evmodin?branch=feat/clone-debug#15a35271f4e7fda41d88cc78216d4900ea03bace"
+source = "git+https://github.com/vorot93/evmodin#ef1bee33aeee962421e32bf23cfb0bb4903a3125"
 dependencies = [
  "arrayvec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,3 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 panic = "abort"
-
-[patch."https://github.com/rust-blockchain/evm"]
-evm = { git = "https://github.com/gakonst/evm", branch = "feat/clone-debug" }
-
-[patch."https://github.com/vorot93/evmodin"]
-evmodin = { git = "https://github.com/gakonst/evmodin", branch = "feat/clone-debug" }

--- a/dapp/src/multi_runner.rs
+++ b/dapp/src/multi_runner.rs
@@ -108,7 +108,7 @@ pub struct MultiContractRunner<E, S> {
 
 impl<E, S> MultiContractRunner<E, S>
 where
-    E: Evm<S> + Clone,
+    E: Evm<S>,
 {
     pub fn test(&mut self, pattern: Regex) -> Result<HashMap<String, HashMap<String, TestResult>>> {
         // NB: We also have access to the contract's abi. When running the test.
@@ -166,7 +166,7 @@ where
 mod tests {
     use super::*;
 
-    fn test_multi_runner<S, E: Clone + Evm<S>>(evm: E) {
+    fn test_multi_runner<S, E: Evm<S>>(evm: E) {
         let mut runner =
             MultiContractRunnerBuilder::default().contracts("./GreetTest.sol").build(evm).unwrap();
 
@@ -187,7 +187,7 @@ mod tests {
         assert_eq!(only_gm["GmTest"].len(), 1);
     }
 
-    fn test_ds_test_fail<S, E: Clone + Evm<S>>(evm: E) {
+    fn test_ds_test_fail<S, E: Evm<S>>(evm: E) {
         let mut runner =
             MultiContractRunnerBuilder::default().contracts("./../FooTest.sol").build(evm).unwrap();
         let results = runner.test(Regex::new(".*").unwrap()).unwrap();

--- a/dapp/src/runner.rs
+++ b/dapp/src/runner.rs
@@ -13,8 +13,7 @@ use std::{collections::HashMap, time::Instant};
 
 use proptest::test_runner::{TestError, TestRunner};
 use serde::{Deserialize, Serialize};
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CounterExample {

--- a/dapp/src/runner.rs
+++ b/dapp/src/runner.rs
@@ -13,6 +13,8 @@ use std::{collections::HashMap, time::Instant};
 
 use proptest::test_runner::{TestError, TestRunner};
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CounterExample {
@@ -35,7 +37,7 @@ pub struct TestResult {
 use std::marker::PhantomData;
 
 pub struct ContractRunner<'a, S, E> {
-    pub evm: &'a mut E,
+    pub evm: Rc<RefCell<&'a mut E>>,
     pub contract: &'a CompiledContract,
     pub address: Address,
     // need to constrain the trait generic
@@ -44,14 +46,11 @@ pub struct ContractRunner<'a, S, E> {
 
 impl<'a, S, E> ContractRunner<'a, S, E> {
     pub fn new(evm: &'a mut E, contract: &'a CompiledContract, address: Address) -> Self {
-        Self { evm, contract, address, state: PhantomData }
+        Self { evm: Rc::new(RefCell::new(evm)), contract, address, state: PhantomData }
     }
 }
 
-impl<'a, S, E: Evm<S>> ContractRunner<'a, S, E>
-where
-    E: Evm<S> + Clone,
-{
+impl<'a, S, E: Evm<S>> ContractRunner<'a, S, E> {
     /// Runs all tests for a contract whose names match the provided regular expression
     pub fn run_tests(
         &mut self,
@@ -111,15 +110,19 @@ where
         // which allows to test multiple assertions in 1 test function while also
         // preserving logs.
         let should_fail = func.name.contains("testFail");
-
         // call the setup function in each test to reset the test's state.
         if setup {
-            self.evm.setup(self.address)?;
+            self.evm.borrow_mut().setup(self.address)?;
         }
 
-        let (_, reason, gas_used) =
-            self.evm.call::<(), _>(Address::zero(), self.address, func, (), 0.into())?;
-        let success = self.evm.check_success(self.address, &reason, should_fail);
+        let (_, reason, gas_used) = self.evm.borrow_mut().call::<(), _>(
+            Address::zero(),
+            self.address,
+            func,
+            (),
+            0.into(),
+        )?;
+        let success = self.evm.borrow_mut().check_success(self.address, &reason, should_fail);
         let duration = Instant::now().duration_since(start);
         tracing::trace!(?duration, %success, %gas_used);
 
@@ -135,7 +138,7 @@ where
     ) -> Result<TestResult> {
         // call the setup function in each test to reset the test's state.
         if setup {
-            self.evm.setup(self.address)?;
+            self.evm.borrow_mut().setup(self.address)?;
         }
 
         let start = Instant::now();
@@ -146,7 +149,8 @@ where
 
         // Run the strategy
         let result = runner.run(&strat, |calldata| {
-            let mut evm = self.evm.clone();
+            let evm = self.evm.clone();
+            let mut evm = evm.borrow_mut();
 
             let (_, reason, _) = evm
                 .call_raw(Address::zero(), self.address, calldata, 0.into(), false)
@@ -219,7 +223,7 @@ mod tests {
             evm.initialize_contracts(vec![(addr, compiled.runtime_bytecode.clone())]);
 
             let mut runner = ContractRunner {
-                evm: &mut evm,
+                evm: Rc::new(RefCell::new(&mut evm)),
                 contract: compiled,
                 address: addr,
                 state: PhantomData,
@@ -275,15 +279,15 @@ mod tests {
         }
     }
 
-    pub fn test_runner<S, E: Clone + Evm<S>>(
-        mut evm: E,
-        addr: Address,
-        compiled: &CompiledContract,
-    ) {
+    pub fn test_runner<S, E: Evm<S>>(mut evm: E, addr: Address, compiled: &CompiledContract) {
         evm.initialize_contracts(vec![(addr, compiled.runtime_bytecode.clone())]);
 
-        let mut runner =
-            ContractRunner { evm: &mut evm, contract: compiled, address: addr, state: PhantomData };
+        let mut runner = ContractRunner {
+            evm: Rc::new(RefCell::new(&mut evm)),
+            contract: compiled,
+            address: addr,
+            state: PhantomData,
+        };
 
         let res = runner.run_tests(&".*".parse().unwrap(), None).unwrap();
         assert!(res.len() > 0);

--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -106,7 +106,7 @@ fn main() -> eyre::Result<()> {
     Ok(())
 }
 
-fn test<S, E: Clone + evm_adapters::Evm<S>>(
+fn test<S, E: evm_adapters::Evm<S>>(
     builder: MultiContractRunnerBuilder,
     evm: E,
     pattern: Regex,

--- a/solc/src/lib.rs
+++ b/solc/src/lib.rs
@@ -369,7 +369,7 @@ mod tests {
             // update this test whenever there's a new sol
             // version. that's ok! good reminder to check the
             // patch notes.
-            (">=0.5.0", "0.8.7"),
+            (">=0.5.0", "0.8.8"),
             // range
             (">=0.4.0 <0.5.0", "0.4.26"),
         ]
@@ -413,7 +413,7 @@ mod tests {
         let versions = builder.contract_versions().unwrap();
         assert_eq!(versions["0.4.14"].len(), 2);
         assert_eq!(versions["0.4.26"].len(), 2);
-        assert_eq!(versions["0.8.7"].len(), 1);
+        assert_eq!(versions["0.8.8"].len(), 1);
 
         rmdir(&dir);
     }


### PR DESCRIPTION
Add a temp interior mutability hack until fuzzing is parallelized that doesn't require patches with Clone support.
`RefCell` alone would be sufficient but the `Rc` ensures we don't do anything stupid with this like threading.