### PR TITLE
[WIP] feat: HEVM Cheat Codes for Sputnik

### DIFF
--- a/evm-adapters/src/sputnik/cheatcode_stack_executor.rs
+++ b/evm-adapters/src/sputnik/cheatcode_stack_executor.rs
@@ -1,0 +1,66 @@
+use std::ops::Deref;
+
+use super::Executor;
+use sputnik::{
+    backend::Backend,
+    executor::{MemoryStackState, Precompile, StackExecutor, StackState, StackSubstateMetadata},
+    Config,
+};
+use std::marker::PhantomData;
+
+struct CheatcodeStackExecutor<'backend, 'config, S, B> {
+    executor: StackExecutor<'config, S>,
+    backend: &'backend B,
+}
+
+impl<'b, S, B> CheatcodeStackExecutor<'b, 'b, S, B>
+where
+    S: StackState<'b>,
+{
+    pub fn new_with_precompile(
+        backend: &'b B,
+        state: S,
+        config: &'b Config,
+        precompile: Precompile,
+    ) -> Self {
+        Self { executor: StackExecutor::new_with_precompile(state, config, precompile), backend }
+    }
+}
+
+impl<'backend, 'config, S, B> Deref for CheatcodeStackExecutor<'backend, 'config, S, B> {
+    type Target = StackExecutor<'config, S>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.executor
+    }
+}
+
+// Concrete implementation over the in-memory backend
+impl<'a, B: Backend>
+    Executor<
+        MemoryStackState<'a, 'a, B>,
+        Config,
+        CheatcodeStackExecutor<'a, 'a, MemoryStackState<'a, 'a, B>, B>,
+    >
+{
+    /// Given a gas limit, vm version, initial chain configuration and initial state
+    // TOOD: See if we can make lifetimes better here
+    pub fn new_with_cheatcode(gas_limit: u64, config: &'a Config, backend: &'a B) -> Self {
+        // setup gasometer
+        let metadata = StackSubstateMetadata::new(gas_limit, config);
+        // setup state
+        let state = MemoryStackState::new(metadata, backend);
+        // setup executor
+        let executor =
+            CheatcodeStackExecutor::new_with_precompile(backend, state, config, Default::default());
+
+        Self { executor, gas_limit, marker: PhantomData }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intercepts_cheat_code() {}
+}

--- a/evm-adapters/src/sputnik/cheatcode_stack_executor.rs
+++ b/evm-adapters/src/sputnik/cheatcode_stack_executor.rs
@@ -1,12 +1,14 @@
 use std::ops::Deref;
 
-use super::Executor;
+use super::{Executor, SputnikExecutor};
 use sputnik::{
     backend::Backend,
     executor::{MemoryStackState, Precompile, StackExecutor, StackState, StackSubstateMetadata},
-    Config,
+    Config, ExitReason,
 };
 use std::marker::PhantomData;
+
+use ethers::types::{H160, H256, U256};
 
 struct CheatcodeStackExecutor<'backend, 'config, S, B> {
     executor: StackExecutor<'config, S>,
@@ -24,6 +26,41 @@ where
         precompile: Precompile,
     ) -> Self {
         Self { executor: StackExecutor::new_with_precompile(state, config, precompile), backend }
+    }
+}
+
+// The implementation for the base Stack Executor just forwards to the internal methods.
+impl<'a, S: StackState<'a>, B: Backend> SputnikExecutor<S, Config>
+    for CheatcodeStackExecutor<'a, 'a, S, B>
+{
+    fn config(&self) -> &Config {
+        self.executor.config()
+    }
+
+    fn state(&self) -> &S {
+        self.executor.state()
+    }
+
+    fn state_mut(&mut self) -> &mut S {
+        self.executor.state_mut()
+    }
+
+    fn gas_left(&self) -> U256 {
+        // NB: We do this to avoid `function cannot return without recursing`
+        U256::from(self.state().metadata().gasometer().gas())
+    }
+
+    fn transact_call(
+        &mut self,
+        caller: H160,
+        address: H160,
+        value: U256,
+        data: Vec<u8>,
+        gas_limit: u64,
+        access_list: Vec<(H160, Vec<H256>)>,
+    ) -> (ExitReason, Vec<u8>) {
+        // TODO: Implement cheat code interception logic.
+        self.executor.transact_call(caller, address, value, data, gas_limit, access_list)
     }
 }
 

--- a/evm-adapters/src/sputnik/cheatcode_stack_executor.rs
+++ b/evm-adapters/src/sputnik/cheatcode_stack_executor.rs
@@ -2,36 +2,123 @@ use std::ops::Deref;
 
 use super::{Executor, SputnikExecutor};
 use sputnik::{
-    backend::Backend,
+    backend::{Backend, Basic},
     executor::{MemoryStackState, Precompile, StackExecutor, StackState, StackSubstateMetadata},
-    Config, ExitReason,
+    Config, ExitReason, Handler,
 };
 use std::marker::PhantomData;
 
+use std::{
+    cell::{RefCell, RefMut},
+    rc::Rc,
+};
+
 use ethers::types::{H160, H256, U256};
 
-struct CheatcodeStackExecutor<'backend, 'config, S, B> {
-    executor: StackExecutor<'config, S>,
-    backend: &'backend B,
+#[derive(Clone, Debug, Default)]
+struct CheatcodeState {
+    block_number: Option<U256>,
+    block_timestamp: Option<u64>,
 }
 
-impl<'b, S, B> CheatcodeStackExecutor<'b, 'b, S, B>
+struct CheatcodeBackend<'a, B> {
+    backend: RefMut<'a, B>,
+    // TODO: remove.
+    #[allow(unused)]
+    state: CheatcodeState,
+}
+
+impl<'a, B: Backend> Backend for CheatcodeBackend<'a, B> {
+    // TODO: Override the return values based on the values of `self.state`
+    fn gas_price(&self) -> U256 {
+        self.backend.gas_price()
+    }
+
+    fn origin(&self) -> H160 {
+        self.backend.origin()
+    }
+
+    fn block_hash(&self, number: U256) -> H256 {
+        self.backend.block_hash(number)
+    }
+
+    fn block_number(&self) -> U256 {
+        self.backend.block_number()
+    }
+
+    fn block_coinbase(&self) -> H160 {
+        self.backend.block_coinbase()
+    }
+
+    fn block_timestamp(&self) -> U256 {
+        self.backend.block_timestamp()
+    }
+
+    fn block_difficulty(&self) -> U256 {
+        self.backend.block_difficulty()
+    }
+
+    fn block_gas_limit(&self) -> U256 {
+        self.backend.block_gas_limit()
+    }
+
+    fn chain_id(&self) -> U256 {
+        self.backend.chain_id()
+    }
+
+    fn exists(&self, address: H160) -> bool {
+        self.backend.exists(address)
+    }
+
+    fn basic(&self, address: H160) -> Basic {
+        self.backend.basic(address)
+    }
+
+    fn code(&self, address: H160) -> Vec<u8> {
+        self.backend.code(address)
+    }
+
+    fn storage(&self, address: H160, index: H256) -> H256 {
+        self.backend.storage(address, index)
+    }
+
+    fn original_storage(&self, address: H160, index: H256) -> Option<H256> {
+        self.backend.original_storage(address, index)
+    }
+}
+
+impl<'a, B: Backend> CheatcodeBackend<'a, B> {
+    fn new(backend: RefMut<'a, B>) -> Self {
+        Self { backend, state: Default::default() }
+    }
+}
+
+struct CheatcodeStackExecutor<'config, S, B> {
+    executor: StackExecutor<'config, S>,
+    backend: CheatcodeBackend<'config, B>,
+}
+
+impl<'c, S, B> CheatcodeStackExecutor<'c, S, B>
 where
-    S: StackState<'b>,
+    S: StackState<'c>,
+    B: Backend,
 {
     pub fn new_with_precompile(
-        backend: &'b B,
+        backend: RefMut<'c, B>,
         state: S,
-        config: &'b Config,
+        config: &'c Config,
         precompile: Precompile,
     ) -> Self {
-        Self { executor: StackExecutor::new_with_precompile(state, config, precompile), backend }
+        Self {
+            executor: StackExecutor::new_with_precompile(state, config, precompile),
+            backend: CheatcodeBackend::new(backend),
+        }
     }
 }
 
 // The implementation for the base Stack Executor just forwards to the internal methods.
 impl<'a, S: StackState<'a>, B: Backend> SputnikExecutor<S, Config>
-    for CheatcodeStackExecutor<'a, 'a, S, B>
+    for CheatcodeStackExecutor<'a, S, B>
 {
     fn config(&self) -> &Config {
         self.executor.config()
@@ -64,7 +151,7 @@ impl<'a, S: StackState<'a>, B: Backend> SputnikExecutor<S, Config>
     }
 }
 
-impl<'backend, 'config, S, B> Deref for CheatcodeStackExecutor<'backend, 'config, S, B> {
+impl<'config, S, B> Deref for CheatcodeStackExecutor<'config, S, B> {
     type Target = StackExecutor<'config, S>;
 
     fn deref(&self) -> &Self::Target {
@@ -77,17 +164,21 @@ impl<'a, B: Backend>
     Executor<
         MemoryStackState<'a, 'a, B>,
         Config,
-        CheatcodeStackExecutor<'a, 'a, MemoryStackState<'a, 'a, B>, B>,
+        CheatcodeStackExecutor<'a, MemoryStackState<'a, 'a, B>, B>,
     >
 {
     /// Given a gas limit, vm version, initial chain configuration and initial state
     // TOOD: See if we can make lifetimes better here
-    pub fn new_with_cheatcode(gas_limit: u64, config: &'a Config, backend: &'a B) -> Self {
+    pub fn new_with_cheatcode(
+        gas_limit: u64,
+        config: &'a Config,
+        immutable_backend: &'a B,
+        backend: RefMut<'a, B>,
+    ) -> Self {
         // setup gasometer
         let metadata = StackSubstateMetadata::new(gas_limit, config);
-        // setup state
-        let state = MemoryStackState::new(metadata, backend);
-        // setup executor
+        let state = MemoryStackState::new(metadata, immutable_backend);
+
         let executor =
             CheatcodeStackExecutor::new_with_precompile(backend, state, config, Default::default());
 
@@ -96,8 +187,27 @@ impl<'a, B: Backend>
 }
 #[cfg(test)]
 mod tests {
+    use crate::sputnik::helpers::{new_backend, new_vicinity};
+    use sputnik::Config;
+
     use super::*;
 
     #[test]
-    fn intercepts_cheat_code() {}
+    fn intercepts_cheat_code() {
+        let cfg = Config::istanbul();
+        let vicinity = new_vicinity();
+        let backend = new_backend(&vicinity, Default::default());
+        // make it clone-able with interior mutability
+        let backend = Rc::new(RefCell::new(backend));
+
+        let b = backend.clone();
+        let used_backend = b.borrow_mut();
+
+        // `BorrowMutError` -> already borrowed, obviously wont' work, need to Clone
+        let backend_immut = &*backend.as_ref().borrow();
+
+        let evm = Executor::new_with_cheatcode(10_000_000, &cfg, backend_immut, used_backend);
+
+        // run hevm test which sets the context
+    }
 }

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -5,7 +5,7 @@ use ethers::types::{Address, Bytes, U256};
 use sputnik::{
     backend::{Backend, MemoryAccount},
     executor::{MemoryStackState, StackExecutor, StackState, StackSubstateMetadata},
-    Config, ExitReason, Handler,
+    Config, ExitReason,
 };
 use std::{collections::BTreeMap, marker::PhantomData};
 
@@ -20,7 +20,7 @@ pub type MemoryState = BTreeMap<Address, MemoryAccount>;
 pub struct Executor<S, C, E> {
     pub executor: E,
     pub gas_limit: u64,
-    marker: PhantomData<(S, C)>,
+    pub(super) marker: PhantomData<(S, C)>,
 }
 
 // Concrete implementation over the in-memory backend

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -7,38 +7,26 @@ use sputnik::{
     executor::{MemoryStackState, StackExecutor, StackState, StackSubstateMetadata},
     Config, ExitReason, Handler,
 };
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, marker::PhantomData};
 
 use eyre::Result;
+
+use super::SputnikExecutor;
 
 pub type MemoryState = BTreeMap<Address, MemoryAccount>;
 
 // TODO: Check if we can implement this as the base layer of an ethers-provider
 // Middleware stack instead of doing RPC calls.
-pub struct Executor<'a, S> {
-    pub executor: StackExecutor<'a, S>,
+pub struct Executor<S, C, E> {
+    pub executor: E,
     pub gas_limit: u64,
-}
-
-// Manual implementation of `Clone` for Clone-able StackStates (typically when the Backend
-// behind them is also clone-able). This is useful to have e.g. when running fuzz
-// tests which we need to take ownership of the EVM and clone it for each run in the
-// test runner's closure.
-impl<'a, S: StackState<'a> + Clone> Clone for Executor<'a, S> {
-    fn clone(&self) -> Self {
-        Self {
-            gas_limit: self.gas_limit,
-            executor: StackExecutor::new_with_precompile(
-                self.executor.state().clone(),
-                self.executor.config(),
-                Default::default(),
-            ),
-        }
-    }
+    marker: PhantomData<(S, C)>,
 }
 
 // Concrete implementation over the in-memory backend
-impl<'a, B: Backend> Executor<'a, MemoryStackState<'a, 'a, B>> {
+impl<'a, B: Backend>
+    Executor<MemoryStackState<'a, 'a, B>, Config, StackExecutor<'a, MemoryStackState<'a, 'a, B>>>
+{
     /// Given a gas limit, vm version, initial chain configuration and initial state
     // TOOD: See if we can make lifetimes better here
     pub fn new(gas_limit: u64, config: &'a Config, backend: &'a B) -> Self {
@@ -49,7 +37,7 @@ impl<'a, B: Backend> Executor<'a, MemoryStackState<'a, 'a, B>> {
         // setup executor
         let executor = StackExecutor::new_with_precompile(state, config, Default::default());
 
-        Self { executor, gas_limit }
+        Self { executor, gas_limit, marker: PhantomData }
     }
 }
 
@@ -58,8 +46,9 @@ impl<'a, B: Backend> Executor<'a, MemoryStackState<'a, 'a, B>> {
 // We use StackState as a trait and not as an associated type because we want to
 // allow the developer what the db type should be. Whereas for ReturnReason, we want it
 // to be generic across implementations, but we don't want to make it a user-controlled generic.
-impl<'a, S> Evm<S> for Executor<'a, S>
+impl<'a, S, C, E> Evm<S> for Executor<S, C, E>
 where
+    E: SputnikExecutor<S, C>,
     S: StackState<'a>,
 {
     type ReturnReason = ExitReason;

--- a/evm-adapters/src/sputnik/mod.rs
+++ b/evm-adapters/src/sputnik/mod.rs
@@ -3,3 +3,60 @@ pub use evm::*;
 
 mod forked_backend;
 pub use forked_backend::ForkMemoryBackend;
+
+use ethers::types::{H160, H256, U256};
+
+use sputnik::{
+    executor::{StackExecutor, StackState},
+    Config, ExitReason,
+};
+
+/// Abstraction over the StackExecutor used inside of Sputnik, so that we can replace
+/// it with one that implements HEVM-style cheatcodes (or other features).
+pub trait SputnikExecutor<S, C> {
+    fn config(&self) -> &C;
+    fn state(&self) -> &S;
+    fn state_mut(&mut self) -> &mut S;
+    fn gas_left(&self) -> U256;
+    fn transact_call(
+        &mut self,
+        caller: H160,
+        address: H160,
+        value: U256,
+        data: Vec<u8>,
+        gas_limit: u64,
+        access_list: Vec<(H160, Vec<H256>)>,
+    ) -> (ExitReason, Vec<u8>);
+}
+
+// The implementation for the base Stack Executor just forwards to the internal methods.
+impl<'a, S: StackState<'a>> SputnikExecutor<S, Config> for StackExecutor<'a, S> {
+    fn config(&self) -> &Config {
+        self.config()
+    }
+
+    fn state(&self) -> &S {
+        self.state()
+    }
+
+    fn state_mut(&mut self) -> &mut S {
+        self.state_mut()
+    }
+
+    fn gas_left(&self) -> U256 {
+        // NB: We do this to avoid `function cannot return without recursing`
+        U256::from(self.state().metadata().gasometer().gas())
+    }
+
+    fn transact_call(
+        &mut self,
+        caller: H160,
+        address: H160,
+        value: U256,
+        data: Vec<u8>,
+        gas_limit: u64,
+        access_list: Vec<(H160, Vec<H256>)>,
+    ) -> (ExitReason, Vec<u8>) {
+        self.transact_call(caller, address, value, data, gas_limit, access_list)
+    }
+}

--- a/evm-adapters/src/sputnik/mod.rs
+++ b/evm-adapters/src/sputnik/mod.rs
@@ -1,6 +1,8 @@
 mod evm;
 pub use evm::*;
 
+mod cheatcode_stack_executor;
+
 mod forked_backend;
 pub use forked_backend::ForkMemoryBackend;
 


### PR DESCRIPTION
1. Generalizes Sputnik's executor to be able to work with both the upstream `StackExecutor` and any implementer of the `SputnikExecutor` trait
2. We implement `SputnikExecutor` for the upstream `StackExecutor`
3. We define a new executor called `CheatcodeStackExecutor` which proceeds to intercept all calls to HEVM's address (same logic as @brockelmore's [prototype](https://github.com/brockelmore/rust-cevm/blob/35cdefb760d41197ccfadc8c446343f20eba9080/src/executor/stack.rs#L857))