### PR TITLE
fix(tests): update tests to work with `solc` version 0.8.9

### DIFF
--- a/solc/src/lib.rs
+++ b/solc/src/lib.rs
@@ -369,7 +369,7 @@ mod tests {
             // update this test whenever there's a new sol
             // version. that's ok! good reminder to check the
             // patch notes.
-            (">=0.5.0", "0.8.8"),
+            (">=0.5.0", "0.8.9"),
             // range
             (">=0.4.0 <0.5.0", "0.4.26"),
         ]
@@ -413,7 +413,7 @@ mod tests {
         let versions = builder.contract_versions().unwrap();
         assert_eq!(versions["0.4.14"].len(), 2);
         assert_eq!(versions["0.4.26"].len(), 2);
-        assert_eq!(versions["0.8.8"].len(), 1);
+        assert_eq!(versions["0.8.9"].len(), 1);
 
         rmdir(&dir);
     }


### PR DESCRIPTION
These need to be updated with every new `solc` release as stated in:
https://github.com/gakonst/dapptools-rs/blob/a189319d233b6a180a6f1c8cb607c33d93a2f382/solc/src/lib.rs#L368-L371