### PR TITLE
feat(seth): support 0x prefixed hex args

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -53,7 +53,7 @@ pub fn encode_input(param: &ParamType, value: &str) -> Result<Token> {
     Ok(match param {
         // TODO: Do the rest of the types
         ParamType::Address => Address::from_str(value)?.into_token(),
-        ParamType::Bytes => Bytes::from(value.from_hex::<Vec<u8>>()?).into_token(),
+        ParamType::Bytes => Bytes::from(value.trim_start_matches("0x").from_hex::<Vec<u8>>()?).into_token(),
         ParamType::FixedBytes(_) => value.from_hex::<Vec<u8>>()?.into_token(),
         ParamType::Uint(n) => {
             let radix = if value.starts_with("0x") { 16 } else { 10 };


### PR DESCRIPTION
Noticed this wasn't supported when playing around with seth. Perhaps this should be upstreamed to ethers-rs? Not sure if this should be tested somewhere? New to rust so any feedback appreciated! 