### PR TITLE
fix: avoid redownloading same solc version

### DIFF
--- a/solc/src/lib.rs
+++ b/solc/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 #[cfg(test)]
 use std::sync::Mutex;
 #[cfg(test)]
-static LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static LOCK: Lazy<Mutex<()>> = Lazy::new(Mutex::default);
 #[cfg(test)]
 use ethers::prelude::Lazy;
 
@@ -131,6 +131,9 @@ impl<'a> SolcBuilder<'a> {
         // take the lock in tests, we use this to enforce that
         // a test does not run while a compiler version is being installed
         let _lock = LOCK.lock();
+
+        // update the locally found versions, to avoid re-downloading the same versions.
+        self.versions = svm::installed_versions().unwrap_or_default();
 
         // load the local / remote versions
         let local_versions = Self::find_matching_installation(&mut self.versions, &sol_version);


### PR DESCRIPTION
This PR fixes #49 

### Existing behaviour
Every test instantiated its own `SolcBuilder` (which happens in parallel), which sets the `versions` field to the locally found solc versions. Multiple tests rely on compiling contracts/libraries that require the same solc version. Since the `SolcBuilder`'s `versions` field was never updated, this meant that the same solc versions were being downloaded multiple times.

The erroneous scenario occurs when:
1. TestA sees that version 0.8.6 is not found (in `self` ), so it tries to install it. After installing it also marks that I have this version.
2. TestB sees that version 0.8.6 is not found (since both were instantiated with that version not found), so it also tries to install it. The installation does not happen in parallel since a lock is acquired just before doing so.
3. TestA believes it has version 0.8.6 so it tries to compile its contracts. But TestB is now installing the same version (at the same path), and hence TestA sees that file as missing (this only happens when the solc binary is being written to the file).

## Fix
We update `self.versions` each time we start the download process, which avoid redownload. Which also means, a partcular version of solc is never overwritten, effectively solving the bug.