### PR TITLE
feat: add seth --to-hexdata seth calldata

### DIFF
--- a/dapptools/src/seth_opts.rs
+++ b/dapptools/src/seth_opts.rs
@@ -17,6 +17,16 @@ pub enum Subcommands {
     #[structopt(name = "--to-hex")]
     #[structopt(about = "convert a decimal number into hex")]
     ToHex { decimal: Option<String> },
+    #[structopt(name = "--to-hexdata")]
+    #[structopt(about = r#"[<hex>|</path>|<@tag>]
+    Output lowercase, 0x-prefixed hex, converting from the
+    input, which can be:
+      - mixed case hex with or without 0x prefix
+      - 0x prefixed hex, concatenated with a ':'
+      - absolute path to file
+      - @tag, where $TAG is defined in environment variables
+    "#)]
+    ToHexdata { input: String },
     #[structopt(name = "--to-checksum-address")]
     #[structopt(about = "convert an address to a checksummed format (EIP-55)")]
     ToCheckSumAddress { address: Address },
@@ -68,6 +78,17 @@ pub enum Subcommands {
         args: Vec<String>,
         #[structopt(long, env = "ETH_RPC_URL")]
         rpc_url: String,
+    },
+    #[structopt(about = "Pack a signature and an argument list into hexadecimal calldata.")]
+    Calldata {
+        #[structopt(
+            help = r#"When called with <sig> of the form <name>(<types>...), then perform ABI encoding to produce the hexadecimal calldata.
+        If the value given—containing at least one slash character—then treat it as a file name to read, and proceed as if the contents were passed as hexadecimal data.
+        Given data, ensure it is hexadecimal calldata starting with 0x and normalize it to lowercase.
+        "#
+        )]
+        sig: String,
+        args: Vec<String>,
     },
     #[structopt(name = "chain")]
     #[structopt(about = "Prints symbolic name of current blockchain by checking genesis hash")]

--- a/seth/src/lib.rs
+++ b/seth/src/lib.rs
@@ -3,6 +3,10 @@
 //! TODO
 use chrono::NaiveDateTime;
 use ethers_core::{
+    abi::{
+        token::{LenientTokenizer, StrictTokenizer, Tokenizer},
+        AbiParser, ParamType, Token,
+    },
     types::*,
     utils::{self, keccak256},
 };
@@ -12,6 +16,7 @@ use rustc_hex::{FromHexIter, ToHex};
 use std::str::FromStr;
 
 use dapp_utils::{encode_args, get_func, to_table};
+use eyre::WrapErr;
 
 // TODO: SethContract with common contract initializers? Same for SethProviders?
 
@@ -523,8 +528,70 @@ impl SimpleSeth {
         let namehash: String = node.to_hex();
         Ok(format!("0x{}", namehash))
     }
+
+    /// Parses string input as Token against the expected ParamType
+    pub fn parse_tokens(params: &[(ParamType, &str)], lenient: bool) -> eyre::Result<Vec<Token>> {
+        params
+            .iter()
+            .map(|&(ref param, value)| {
+                if lenient {
+                    LenientTokenizer::tokenize(param, value)
+                } else {
+                    StrictTokenizer::tokenize(param, value)
+                }
+            })
+            .collect::<Result<_, _>>()
+            .wrap_err("Failed to parse tokens")
+    }
+
+    /// Performs ABI encoding to produce the hexadecimal calldata with the given arguments.
+    ///
+    /// ```
+    /// # use seth::SimpleSeth as Seth;
+    ///
+    /// # fn main() -> eyre::Result<()> {
+    ///     assert_eq!(
+    ///         "0xb3de648b0000000000000000000000000000000000000000000000000000000000000001",
+    ///         Seth::calldata("f(uint a)", &["1"]).unwrap().as_str()
+    ///     );
+    /// #    Ok(())
+    /// # }
+    /// ```
+    pub fn calldata(sig: impl AsRef<str>, args: &[impl AsRef<str>]) -> Result<String> {
+        let fun = AbiParser::default().parse_function(sig.as_ref())?;
+        let params: Vec<_> = fun
+            .inputs
+            .iter()
+            .map(|param| param.kind.clone())
+            .zip(args.iter().map(AsRef::as_ref))
+            .collect();
+        let tokens = SimpleSeth::parse_tokens(&params, true)?;
+        let calldata = fun.encode_input(&tokens)?;
+        Ok(format!("0x{}", calldata.to_hex::<String>()))
+    }
 }
 
 fn strip_0x(s: &str) -> &str {
     s.strip_prefix("0x").unwrap_or(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SimpleSeth as Seth;
+
+    #[test]
+    fn calldata_uint() {
+        assert_eq!(
+            "0xb3de648b0000000000000000000000000000000000000000000000000000000000000001",
+            Seth::calldata("f(uint a)", &["1"]).unwrap().as_str()
+        );
+    }
+
+    #[test]
+    fn calldata_bool() {
+        assert_eq!(
+            "0x6fae94120000000000000000000000000000000000000000000000000000000000000000",
+            Seth::calldata("bar(bool)", &["false"]).unwrap().as_str()
+        );
+    }
 }


### PR DESCRIPTION
# Changes
* Add `seth --to-hexdata`
* Add `seth calldata`

The calldata subcommand is not fully on par with OG calldata and lacks proper support for arrays

Also we should think about extracting all subcommand logic to separate modules so that we can test them idividually.