### PR TITLE
feat: initial draft non blocking middleware provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,7 @@ dependencies = [
  "evm",
  "evmodin",
  "eyre",
+ "futures",
  "hex",
  "once_cell",
  "proptest",

--- a/evm-adapters/Cargo.toml
+++ b/evm-adapters/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1.12.0", features = ["rt-multi-thread"] }
 hex = "0.4.3"
 thiserror = "1.0.29"
 proptest = "1.0.0"
+futures = "0.3.17"
 
 [dev-dependencies]
 evmodin = { git = "https://github.com/vorot93/evmodin", features = ["util"] }


### PR DESCRIPTION
## Changes
* Adds a new SyncProvider type that works like a block working of a `Middleware`, it spawns the actual `Middleware` to a background thread and executes requests via channels