### PR TITLE
fix fuzzer bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.30.1"
-source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#bbb1ba18a1efd87b1d578aec5dda9264932ddf2c"
+source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#8e10066971eaf782ac1b5191802925227cecbab1"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#bbb1ba18a1efd87b1d578aec5dda9264932ddf2c"
+source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#8e10066971eaf782ac1b5191802925227cecbab1"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#bbb1ba18a1efd87b1d578aec5dda9264932ddf2c"
+source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#8e10066971eaf782ac1b5191802925227cecbab1"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1129,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#bbb1ba18a1efd87b1d578aec5dda9264932ddf2c"
+source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#8e10066971eaf782ac1b5191802925227cecbab1"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/dapp/src/multi_runner.rs
+++ b/dapp/src/multi_runner.rs
@@ -108,6 +108,7 @@ pub struct MultiContractRunner<E, S> {
 impl<E, S> MultiContractRunner<E, S>
 where
     E: Evm<S>,
+    S: Clone,
 {
     pub fn test(&mut self, pattern: Regex) -> Result<HashMap<String, HashMap<String, TestResult>>> {
         // NB: We also have access to the contract's abi. When running the test.
@@ -165,7 +166,7 @@ where
 mod tests {
     use super::*;
 
-    fn test_multi_runner<S, E: Evm<S>>(evm: E) {
+    fn test_multi_runner<S: Clone, E: Evm<S>>(evm: E) {
         let mut runner =
             MultiContractRunnerBuilder::default().contracts("./GreetTest.sol").build(evm).unwrap();
 
@@ -186,7 +187,7 @@ mod tests {
         assert_eq!(only_gm["GmTest"].len(), 1);
     }
 
-    fn test_ds_test_fail<S, E: Evm<S>>(evm: E) {
+    fn test_ds_test_fail<S: Clone, E: Evm<S>>(evm: E) {
         let mut runner =
             MultiContractRunnerBuilder::default().contracts("./../FooTest.sol").build(evm).unwrap();
         let results = runner.test(Regex::new(".*").unwrap()).unwrap();

--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -12,7 +12,7 @@ use ansi_term::Colour;
 mod dapp_opts;
 use dapp_opts::{BuildOpts, EvmType, Opts, Subcommands};
 
-use std::convert::TryFrom;
+use std::{convert::TryFrom, sync::Arc};
 
 mod utils;
 
@@ -70,6 +70,7 @@ fn main() -> eyre::Result<()> {
                     } else {
                         Box::new(backend)
                     };
+                    let backend = Arc::new(backend);
 
                     let evm = Executor::new_with_cheatcodes(backend, env.gas_limit, &cfg);
                     test(builder, evm, pattern, json)?;
@@ -111,7 +112,7 @@ fn main() -> eyre::Result<()> {
     Ok(())
 }
 
-fn test<S, E: evm_adapters::Evm<S>>(
+fn test<S: Clone, E: evm_adapters::Evm<S>>(
     builder: MultiContractRunnerBuilder,
     evm: E,
     pattern: Regex,

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -3,7 +3,10 @@ use ethers::{
     abi::{Function, ParamType, Token, Tokenizable},
     types::{Address, Bytes, Sign, I256, U256},
 };
-use std::{cell::{RefCell, RefMut}, marker::PhantomData};
+use std::{
+    cell::{RefCell, RefMut},
+    marker::PhantomData,
+};
 
 use proptest::{
     prelude::*,

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -37,20 +37,41 @@ impl<'a, S, E: Evm<S>> FuzzedExecutor<'a, E, S> {
         func: &Function,
         address: Address,
         should_fail: bool,
-    ) -> Result<(), TestError<Bytes>> {
+    ) -> Result<(), TestError<Bytes>>
+    where
+        // We need to be able to clone the state so as to snapshot it and reset
+        // it back after every test run, to have isolation of state across each
+        // fuzz test run.
+        S: Clone,
+    {
         let strat = fuzz_calldata(func);
+
+        // Snapshot the state before the test starts running
+        let pre_test_state = self.evm.borrow().state().clone();
 
         let mut runner = self.runner.clone();
         runner.run(&strat, |calldata| {
             let mut evm = self.evm.borrow_mut();
-            let (_, reason, _) = evm
+
+            // Before each test, we must reset to the initial state
+            evm.reset(pre_test_state.clone());
+
+            let (returndata, reason, _) = evm
                 .call_raw(Address::zero(), address, calldata, 0.into(), false)
                 .expect("could not make raw evm call");
 
+            // We must check success before resetting the state, otherwise resetting the state
+            // will also reset the `failed` state variable back to false.
             let success = evm.check_success(address, &reason, should_fail);
 
             // This will panic and get caught by the executor
-            proptest::prop_assert!(success);
+            proptest::prop_assert!(
+                success,
+                "{}, expected failure: {}, reason: '{}'",
+                func.name,
+                should_fail,
+                dapp_utils::decode_revert(returndata.as_ref())?
+            );
 
             Ok(())
         })

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -85,7 +85,7 @@ pub trait Evm<State> {
         args: T, // derive arbitrary for Tokenize?
         value: U256,
     ) -> Result<(Bytes, Self::ReturnReason, u64)> {
-        let calldata = encode_function_data(&func, args)?;
+        let calldata = encode_function_data(func, args)?;
         #[allow(deprecated)]
         let is_static = func.constant ||
             matches!(

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -55,9 +55,6 @@ pub trait Evm<State> {
     /// Resets the EVM's state to the provided value
     fn reset(&mut self, state: State);
 
-    /// Executes the specified EVM call against the state
-    // TODO: Should we just make this take a `TransactionRequest` or other more
-    // ergonomic type?
     fn call<D: Detokenize, T: Tokenize, F: IntoFunction>(
         &mut self,
         from: Address,
@@ -67,15 +64,7 @@ pub trait Evm<State> {
         value: U256,
     ) -> std::result::Result<(D, Self::ReturnReason, u64), EvmError> {
         let func = func.into();
-        let calldata = encode_function_data(&func, args)?;
-        #[allow(deprecated)]
-        let is_static = func.constant ||
-            matches!(
-                func.state_mutability,
-                ethers::abi::StateMutability::View | ethers::abi::StateMutability::Pure
-            );
-        let (retdata, status, gas) = self.call_raw(from, to, calldata, value, is_static)?;
-
+        let (retdata, status, gas) = self.call_unchecked(from, to, &func, args, value)?;
         if Self::is_fail(&status) {
             let reason = dapp_utils::decode_revert(retdata.as_ref()).map_err(AbiError::from)?;
             Err(EvmError::Execution { reason, gas_used: gas })
@@ -83,6 +72,27 @@ pub trait Evm<State> {
             let retdata = decode_function_data(&func, retdata, false)?;
             Ok((retdata, status, gas))
         }
+    }
+
+    /// Executes the specified EVM call against the state
+    // TODO: Should we just make this take a `TransactionRequest` or other more
+    // ergonomic type?
+    fn call_unchecked<T: Tokenize>(
+        &mut self,
+        from: Address,
+        to: Address,
+        func: &ethers::abi::Function,
+        args: T, // derive arbitrary for Tokenize?
+        value: U256,
+    ) -> Result<(Bytes, Self::ReturnReason, u64)> {
+        let calldata = encode_function_data(&func, args)?;
+        #[allow(deprecated)]
+        let is_static = func.constant ||
+            matches!(
+                func.state_mutability,
+                ethers::abi::StateMutability::View | ethers::abi::StateMutability::Pure
+            );
+        self.call_raw(from, to, calldata, value, is_static)
     }
 
     fn call_raw(
@@ -98,7 +108,6 @@ pub trait Evm<State> {
     fn setup(&mut self, address: Address) -> Result<Self::ReturnReason> {
         let (_, status, _) =
             self.call::<(), _, _>(Address::zero(), address, "setUp()", (), 0.into())?;
-        // debug_assert_eq!(status, ExitReason::Succeed(ExitSucceed::Stopped));
         Ok(status)
     }
 

--- a/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
@@ -11,6 +11,7 @@ use ethers::types::{H160, H256, U256};
 /// We had to copy it so that we can modify the Stack's internal backend, because
 /// the upstream MemoryStackState only has an immutable reference to `Backend` which
 /// does not allow us to do so.
+#[derive(Clone)]
 pub struct MemoryStackStateOwned<'config, B> {
     pub backend: B,
     substate: MemoryStackSubstate<'config>,

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -1,0 +1,124 @@
+// Taken from:
+// https://github.com/dapphub/dapptools/blob/e41b6cd9119bbd494aba1236838b859f2136696b/src/dapp-tests/pass/cheatCodes.sol
+pragma solidity ^0.6.7;
+pragma experimental ABIEncoderV2;
+
+import "./DsTest.sol";
+
+interface Hevm {
+    function warp(uint256) external;
+    function roll(uint256) external;
+    function load(address,bytes32) external returns (bytes32);
+    function store(address,bytes32,bytes32) external;
+    function sign(uint256,bytes32) external returns (uint8,bytes32,bytes32);
+    function addr(uint256) external returns (address);
+    function ffi(string[] calldata) external returns (bytes memory);
+}
+
+contract HasStorage {
+    uint slot0 = 10;
+}
+
+// We add `assertEq` tests as well to ensure that our test runner checks the
+// `failed` variable.
+contract CheatCodes is DSTest {
+    // address store = address(new HasStorage());
+    Hevm constant hevm = Hevm(HEVM_ADDRESS);
+
+    // Warp
+
+    function testWarp(uint128 jump) public {
+        uint pre = block.timestamp;
+        hevm.warp(block.timestamp + jump);
+        require(block.timestamp == pre + jump, "warp failed");
+    }
+
+    function testWarpAssertEq(uint128 jump) public {
+        uint pre = block.timestamp;
+        hevm.warp(block.timestamp + jump);
+        assertEq(block.timestamp, pre + jump);
+    }
+
+    function testFailWarp(uint128 jump) public {
+        uint pre = block.timestamp;
+        hevm.warp(block.timestamp + jump);
+        require(block.timestamp == pre + jump + 1, "warp failed");
+    }
+
+    function testFailWarpAssert(uint128 jump) public {
+        uint pre = block.timestamp;
+        hevm.warp(block.timestamp + jump);
+        assertEq(block.timestamp, pre + jump + 1);
+    }
+
+    // Roll
+
+    // Underscore does not run the fuzz test?!
+    function testRoll(uint256 jump) public {
+        uint pre = block.number;
+        hevm.roll(block.number + jump);
+        require(block.number == pre + jump, "roll failed");
+    }
+
+    function testFailRoll(uint32 jump) public {
+        uint pre = block.number;
+        hevm.roll(block.number + jump);
+        assertEq(block.number, pre + jump + 1);
+    }
+
+    // function prove_warp_symbolic(uint128 jump) public {
+    //     test_warp_concrete(jump);
+    // }
+
+
+    // function test_store_load_concrete(uint x) public {
+    //     uint ten = uint(hevm.load(store, bytes32(0)));
+    //     assertEq(ten, 10);
+
+    //     hevm.store(store, bytes32(0), bytes32(x));
+    //     uint val = uint(hevm.load(store, bytes32(0)));
+    //     assertEq(val, x);
+    // }
+
+    // function prove_store_load_symbolic(uint x) public {
+    //     test_store_load_concrete(x);
+    // }
+
+    // function test_sign_addr_digest(uint sk, bytes32 digest) public {
+    //     if (sk == 0) return; // invalid key
+
+    //     (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, digest);
+    //     address expected = hevm.addr(sk);
+    //     address actual = ecrecover(digest, v, r, s);
+
+    //     assertEq(actual, expected);
+    // }
+
+    // function test_sign_addr_message(uint sk, bytes memory message) public {
+    //     test_sign_addr_digest(sk, keccak256(message));
+    // }
+
+    // function testFail_sign_addr(uint sk, bytes32 digest) public {
+    //     uint badKey = sk + 1;
+
+    //     (uint8 v, bytes32 r, bytes32 s) = hevm.sign(badKey, digest);
+    //     address expected = hevm.addr(sk);
+    //     address actual = ecrecover(digest, v, r, s);
+
+    //     assertEq(actual, expected);
+    // }
+
+    // function testFail_addr_zero_sk() public {
+    //     hevm.addr(0);
+    // }
+
+    // function testFFI() public {
+    //     string[] memory inputs = new string[](3);
+    //     inputs[0] = "echo";
+    //     inputs[1] = "-n";
+    //     inputs[2] = "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046163616200000000000000000000000000000000000000000000000000000000";
+
+    //     (string memory output) = abi.decode(hevm.ffi(inputs), (string));
+    //     assertEq(output, "acab");
+    // }
+}

--- a/evm-adapters/testdata/DsTest.sol
+++ b/evm-adapters/testdata/DsTest.sol
@@ -1,0 +1,435 @@
+// Taken from: https://github.com/dapphub/ds-test/blob/0a5da56b0d65960e6a994d2ec8245e6edd38c248/src/test.sol
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.4.23;
+
+contract DSTest {
+    event log                    (string);
+    event logs                   (bytes);
+
+    event log_address            (address);
+    event log_bytes32            (bytes32);
+    event log_int                (int);
+    event log_uint               (uint);
+    event log_bytes              (bytes);
+    event log_string             (string);
+
+    event log_named_address      (string key, address val);
+    event log_named_bytes32      (string key, bytes32 val);
+    event log_named_decimal_int  (string key, int val, uint decimals);
+    event log_named_decimal_uint (string key, uint val, uint decimals);
+    event log_named_int          (string key, int val);
+    event log_named_uint         (string key, uint val);
+    event log_named_bytes        (string key, bytes val);
+    event log_named_string       (string key, string val);
+
+    bool public IS_TEST = true;
+    bool public failed;
+
+    address constant HEVM_ADDRESS =
+        address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
+
+    modifier mayRevert() { _; }
+    modifier testopts(string memory) { _; }
+
+    function fail() internal {
+        failed = true;
+    }
+
+    modifier logs_gas() {
+        uint startGas = gasleft();
+        _;
+        uint endGas = gasleft();
+        emit log_named_uint("gas", startGas - endGas);
+    }
+
+    function assertTrue(bool condition) internal {
+        if (!condition) {
+            emit log("Error: Assertion Failed");
+            fail();
+        }
+    }
+
+    function assertTrue(bool condition, string memory err) internal {
+        if (!condition) {
+            emit log_named_string("Error", err);
+            assertTrue(condition);
+        }
+    }
+
+    function assertEq(address a, address b) internal {
+        if (a != b) {
+            emit log("Error: a == b not satisfied [address]");
+            emit log_named_address("  Expected", b);
+            emit log_named_address("    Actual", a);
+            fail();
+        }
+    }
+    function assertEq(address a, address b, string memory err) internal {
+        if (a != b) {
+            emit log_named_string ("Error", err);
+            assertEq(a, b);
+        }
+    }
+
+    function assertEq(bytes32 a, bytes32 b) internal {
+        if (a != b) {
+            emit log("Error: a == b not satisfied [bytes32]");
+            emit log_named_bytes32("  Expected", b);
+            emit log_named_bytes32("    Actual", a);
+            fail();
+        }
+    }
+    function assertEq(bytes32 a, bytes32 b, string memory err) internal {
+        if (a != b) {
+            emit log_named_string ("Error", err);
+            assertEq(a, b);
+        }
+    }
+    function assertEq32(bytes32 a, bytes32 b) internal {
+        assertEq(a, b);
+    }
+    function assertEq32(bytes32 a, bytes32 b, string memory err) internal {
+        assertEq(a, b, err);
+    }
+
+    function assertEq(int a, int b) internal {
+        if (a != b) {
+            emit log("Error: a == b not satisfied [int]");
+            emit log_named_int("  Expected", b);
+            emit log_named_int("    Actual", a);
+            fail();
+        }
+    }
+    function assertEq(int a, int b, string memory err) internal {
+        if (a != b) {
+            emit log_named_string("Error", err);
+            assertEq(a, b);
+        }
+    }
+    function assertEq(uint a, uint b) internal {
+        if (a != b) {
+            emit log("Error: a == b not satisfied [uint]");
+            emit log_named_uint("  Expected", b);
+            emit log_named_uint("    Actual", a);
+            fail();
+        }
+    }
+    function assertEq(uint a, uint b, string memory err) internal {
+        if (a != b) {
+            emit log_named_string("Error", err);
+            assertEq(a, b);
+        }
+    }
+    function assertEqDecimal(int a, int b, uint decimals) internal {
+        if (a != b) {
+            emit log("Error: a == b not satisfied [decimal int]");
+            emit log_named_decimal_int("  Expected", b, decimals);
+            emit log_named_decimal_int("    Actual", a, decimals);
+            fail();
+        }
+    }
+    function assertEqDecimal(int a, int b, uint decimals, string memory err) internal {
+        if (a != b) {
+            emit log_named_string("Error", err);
+            assertEqDecimal(a, b, decimals);
+        }
+    }
+    function assertEqDecimal(uint a, uint b, uint decimals) internal {
+        if (a != b) {
+            emit log("Error: a == b not satisfied [decimal uint]");
+            emit log_named_decimal_uint("  Expected", b, decimals);
+            emit log_named_decimal_uint("    Actual", a, decimals);
+            fail();
+        }
+    }
+    function assertEqDecimal(uint a, uint b, uint decimals, string memory err) internal {
+        if (a != b) {
+            emit log_named_string("Error", err);
+            assertEqDecimal(a, b, decimals);
+        }
+    }
+
+    function assertGt(uint a, uint b) internal {
+        if (a <= b) {
+            emit log("Error: a > b not satisfied [uint]");
+            emit log_named_uint("  Value a", a);
+            emit log_named_uint("  Value b", b);
+            fail();
+        }
+    }
+    function assertGt(uint a, uint b, string memory err) internal {
+        if (a <= b) {
+            emit log_named_string("Error", err);
+            assertGt(a, b);
+        }
+    }
+    function assertGt(int a, int b) internal {
+        if (a <= b) {
+            emit log("Error: a > b not satisfied [int]");
+            emit log_named_int("  Value a", a);
+            emit log_named_int("  Value b", b);
+            fail();
+        }
+    }
+    function assertGt(int a, int b, string memory err) internal {
+        if (a <= b) {
+            emit log_named_string("Error", err);
+            assertGt(a, b);
+        }
+    }
+    function assertGtDecimal(int a, int b, uint decimals) internal {
+        if (a <= b) {
+            emit log("Error: a > b not satisfied [decimal int]");
+            emit log_named_decimal_int("  Value a", a, decimals);
+            emit log_named_decimal_int("  Value b", b, decimals);
+            fail();
+        }
+    }
+    function assertGtDecimal(int a, int b, uint decimals, string memory err) internal {
+        if (a <= b) {
+            emit log_named_string("Error", err);
+            assertGtDecimal(a, b, decimals);
+        }
+    }
+    function assertGtDecimal(uint a, uint b, uint decimals) internal {
+        if (a <= b) {
+            emit log("Error: a > b not satisfied [decimal uint]");
+            emit log_named_decimal_uint("  Value a", a, decimals);
+            emit log_named_decimal_uint("  Value b", b, decimals);
+            fail();
+        }
+    }
+    function assertGtDecimal(uint a, uint b, uint decimals, string memory err) internal {
+        if (a <= b) {
+            emit log_named_string("Error", err);
+            assertGtDecimal(a, b, decimals);
+        }
+    }
+
+    function assertGe(uint a, uint b) internal {
+        if (a < b) {
+            emit log("Error: a >= b not satisfied [uint]");
+            emit log_named_uint("  Value a", a);
+            emit log_named_uint("  Value b", b);
+            fail();
+        }
+    }
+    function assertGe(uint a, uint b, string memory err) internal {
+        if (a < b) {
+            emit log_named_string("Error", err);
+            assertGe(a, b);
+        }
+    }
+    function assertGe(int a, int b) internal {
+        if (a < b) {
+            emit log("Error: a >= b not satisfied [int]");
+            emit log_named_int("  Value a", a);
+            emit log_named_int("  Value b", b);
+            fail();
+        }
+    }
+    function assertGe(int a, int b, string memory err) internal {
+        if (a < b) {
+            emit log_named_string("Error", err);
+            assertGe(a, b);
+        }
+    }
+    function assertGeDecimal(int a, int b, uint decimals) internal {
+        if (a < b) {
+            emit log("Error: a >= b not satisfied [decimal int]");
+            emit log_named_decimal_int("  Value a", a, decimals);
+            emit log_named_decimal_int("  Value b", b, decimals);
+            fail();
+        }
+    }
+    function assertGeDecimal(int a, int b, uint decimals, string memory err) internal {
+        if (a < b) {
+            emit log_named_string("Error", err);
+            assertGeDecimal(a, b, decimals);
+        }
+    }
+    function assertGeDecimal(uint a, uint b, uint decimals) internal {
+        if (a < b) {
+            emit log("Error: a >= b not satisfied [decimal uint]");
+            emit log_named_decimal_uint("  Value a", a, decimals);
+            emit log_named_decimal_uint("  Value b", b, decimals);
+            fail();
+        }
+    }
+    function assertGeDecimal(uint a, uint b, uint decimals, string memory err) internal {
+        if (a < b) {
+            emit log_named_string("Error", err);
+            assertGeDecimal(a, b, decimals);
+        }
+    }
+
+    function assertLt(uint a, uint b) internal {
+        if (a >= b) {
+            emit log("Error: a < b not satisfied [uint]");
+            emit log_named_uint("  Value a", a);
+            emit log_named_uint("  Value b", b);
+            fail();
+        }
+    }
+    function assertLt(uint a, uint b, string memory err) internal {
+        if (a >= b) {
+            emit log_named_string("Error", err);
+            assertLt(a, b);
+        }
+    }
+    function assertLt(int a, int b) internal {
+        if (a >= b) {
+            emit log("Error: a < b not satisfied [int]");
+            emit log_named_int("  Value a", a);
+            emit log_named_int("  Value b", b);
+            fail();
+        }
+    }
+    function assertLt(int a, int b, string memory err) internal {
+        if (a >= b) {
+            emit log_named_string("Error", err);
+            assertLt(a, b);
+        }
+    }
+    function assertLtDecimal(int a, int b, uint decimals) internal {
+        if (a >= b) {
+            emit log("Error: a < b not satisfied [decimal int]");
+            emit log_named_decimal_int("  Value a", a, decimals);
+            emit log_named_decimal_int("  Value b", b, decimals);
+            fail();
+        }
+    }
+    function assertLtDecimal(int a, int b, uint decimals, string memory err) internal {
+        if (a >= b) {
+            emit log_named_string("Error", err);
+            assertLtDecimal(a, b, decimals);
+        }
+    }
+    function assertLtDecimal(uint a, uint b, uint decimals) internal {
+        if (a >= b) {
+            emit log("Error: a < b not satisfied [decimal uint]");
+            emit log_named_decimal_uint("  Value a", a, decimals);
+            emit log_named_decimal_uint("  Value b", b, decimals);
+            fail();
+        }
+    }
+    function assertLtDecimal(uint a, uint b, uint decimals, string memory err) internal {
+        if (a >= b) {
+            emit log_named_string("Error", err);
+            assertLtDecimal(a, b, decimals);
+        }
+    }
+
+    function assertLe(uint a, uint b) internal {
+        if (a > b) {
+            emit log("Error: a <= b not satisfied [uint]");
+            emit log_named_uint("  Value a", a);
+            emit log_named_uint("  Value b", b);
+            fail();
+        }
+    }
+    function assertLe(uint a, uint b, string memory err) internal {
+        if (a > b) {
+            emit log_named_string("Error", err);
+            assertLe(a, b);
+        }
+    }
+    function assertLe(int a, int b) internal {
+        if (a > b) {
+            emit log("Error: a <= b not satisfied [int]");
+            emit log_named_int("  Value a", a);
+            emit log_named_int("  Value b", b);
+            fail();
+        }
+    }
+    function assertLe(int a, int b, string memory err) internal {
+        if (a > b) {
+            emit log_named_string("Error", err);
+            assertLe(a, b);
+        }
+    }
+    function assertLeDecimal(int a, int b, uint decimals) internal {
+        if (a > b) {
+            emit log("Error: a <= b not satisfied [decimal int]");
+            emit log_named_decimal_int("  Value a", a, decimals);
+            emit log_named_decimal_int("  Value b", b, decimals);
+            fail();
+        }
+    }
+    function assertLeDecimal(int a, int b, uint decimals, string memory err) internal {
+        if (a > b) {
+            emit log_named_string("Error", err);
+            assertLeDecimal(a, b, decimals);
+        }
+    }
+    function assertLeDecimal(uint a, uint b, uint decimals) internal {
+        if (a > b) {
+            emit log("Error: a <= b not satisfied [decimal uint]");
+            emit log_named_decimal_uint("  Value a", a, decimals);
+            emit log_named_decimal_uint("  Value b", b, decimals);
+            fail();
+        }
+    }
+    function assertLeDecimal(uint a, uint b, uint decimals, string memory err) internal {
+        if (a > b) {
+            emit log_named_string("Error", err);
+            assertGeDecimal(a, b, decimals);
+        }
+    }
+
+    function assertEq(string memory a, string memory b) internal {
+        if (keccak256(abi.encodePacked(a)) != keccak256(abi.encodePacked(b))) {
+            emit log("Error: a == b not satisfied [string]");
+            emit log_named_string("  Value a", a);
+            emit log_named_string("  Value b", b);
+            fail();
+        }
+    }
+    function assertEq(string memory a, string memory b, string memory err) internal {
+        if (keccak256(abi.encodePacked(a)) != keccak256(abi.encodePacked(b))) {
+            emit log_named_string("Error", err);
+            assertEq(a, b);
+        }
+    }
+
+    function checkEq0(bytes memory a, bytes memory b) internal pure returns (bool ok) {
+        ok = true;
+        if (a.length == b.length) {
+            for (uint i = 0; i < a.length; i++) {
+                if (a[i] != b[i]) {
+                    ok = false;
+                }
+            }
+        } else {
+            ok = false;
+        }
+    }
+    function assertEq0(bytes memory a, bytes memory b) internal {
+        if (!checkEq0(a, b)) {
+            emit log("Error: a == b not satisfied [bytes]");
+            emit log_named_bytes("  Expected", a);
+            emit log_named_bytes("    Actual", b);
+            fail();
+        }
+    }
+    function assertEq0(bytes memory a, bytes memory b, string memory err) internal {
+        if (!checkEq0(a, b)) {
+            emit log_named_string("Error", err);
+            assertEq0(a, b);
+        }
+    }
+}


### PR DESCRIPTION
Apparently because we were doing `borrow_mut()` on the test runner, some tests would not run. This was quite weird to see. 

This test fixes it, as well as adds fuzzing tests usinga both `require` and ds-test style `assertEq`, and resets fuzz test state before a test runs.

This sets our testing infra up for adding any remaining cheat codes.

Note: It'd be nice if we can reset state w/o requiring these large clones. The state diff approach should fix it.