### PR TITLE
feat: store / load cheatcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.30.1"
-source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#8e10066971eaf782ac1b5191802925227cecbab1"
+source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#ca5ba10367e0b66d5aeb68cd3ceae772075b55dd"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#8e10066971eaf782ac1b5191802925227cecbab1"
+source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#ca5ba10367e0b66d5aeb68cd3ceae772075b55dd"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#8e10066971eaf782ac1b5191802925227cecbab1"
+source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#ca5ba10367e0b66d5aeb68cd3ceae772075b55dd"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1129,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.30.0"
-source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#8e10066971eaf782ac1b5191802925227cecbab1"
+source = "git+https://github.com/gakonst/evm?branch=chore/expose-stack-module#ca5ba10367e0b66d5aeb68cd3ceae772075b55dd"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -16,14 +16,23 @@ interface Hevm {
 }
 
 contract HasStorage {
-    uint slot0 = 10;
+    uint public slot0 = 10;
+
+    function setUp() public {
+        slot0 = 10;
+    }
 }
 
 // We add `assertEq` tests as well to ensure that our test runner checks the
 // `failed` variable.
 contract CheatCodes is DSTest {
-    // address store = address(new HasStorage());
+    address public store;
     Hevm constant hevm = Hevm(HEVM_ADDRESS);
+
+    function setUp() public {
+        store = address(new HasStorage());
+        HasStorage(store).setUp();
+    }
 
     // Warp
 
@@ -71,14 +80,14 @@ contract CheatCodes is DSTest {
     // }
 
 
-    // function test_store_load_concrete(uint x) public {
-    //     uint ten = uint(hevm.load(store, bytes32(0)));
-    //     assertEq(ten, 10);
+    function test_store_load_concrete(uint x) public {
+        uint ten = uint(hevm.load(store, bytes32(0)));
+        assertEq(ten, 10);
 
-    //     hevm.store(store, bytes32(0), bytes32(x));
-    //     uint val = uint(hevm.load(store, bytes32(0)));
-    //     assertEq(val, x);
-    // }
+        hevm.store(store, bytes32(0), bytes32(x));
+        uint val = uint(hevm.load(store, bytes32(0)));
+        assertEq(val, x);
+    }
 
     // function prove_store_load_symbolic(uint x) public {
     //     test_store_load_concrete(x);


### PR DESCRIPTION
Self-explanatory, `hevm.store` to override storage slots, `hevm.load` to load the value in them