### PR TITLE
fix: make test suite more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Benchmarks TBD in the future, but:
 ## Tested Against
 
 This repository has been tested against the following DappTools repos:
-*
+* [LootLoose](https://github.com/gakonst/lootloose/) (minus the FFI tests)
+* [solmate](https://github.com/Rari-Capital/solmate/) (replace all the `prove` symbolic tests with fuzz tests, and skip `invariant` tests for now)
+
 ## Development
 
 ### Rust Toolchain

--- a/dapp/GreetTest.sol
+++ b/dapp/GreetTest.sol
@@ -36,20 +36,20 @@ contract GreeterTest is GreeterTestSetup {
     }
 
 
-    function testFuzzString(string memory myGreeting) public {
+    function testStringFuzz(string memory myGreeting) public {
         greeter.greet(myGreeting);
         require(keccak256(abi.encodePacked(greeter.greeting())) == keccak256(abi.encodePacked(myGreeting)), "not equal");
     }
 
     function testFuzzFixedArray(uint256[2] memory x) public {
-        if (x[0] == 0) return;
+        // filter out x[1] == 0 since it'll drain all our gas in the
+        // division by zero from all future tests
+        if (x[1] == 0) return;
         require(x[1] / x[1] == 0);
     }
 
     function testFuzzVariableArray(uint256[] memory x) public {
-        if (x.length < 2) return;
-        if (x[0] == 0) return;
-        require(x[1] / x[1] == 0);
+        require(x[0] == x[1]);
     }
 
     function testFuzzBytes1(bytes1 x) public {

--- a/dapp/src/multi_runner.rs
+++ b/dapp/src/multi_runner.rs
@@ -7,7 +7,7 @@ use ethers::{types::Address, utils::CompiledContract};
 use proptest::test_runner::TestRunner;
 use regex::Regex;
 
-use eyre::Result;
+use eyre::{Context, Result};
 use std::{collections::HashMap, marker::PhantomData, path::PathBuf};
 
 /// Builder used for instantiating the multi-contract runner
@@ -48,7 +48,9 @@ impl<'a> MultiContractRunnerBuilder<'a> {
         let addresses = contracts
             .iter()
             .map(|(name, compiled)| {
-                let (addr, _, _) = evm.deploy(deployer, compiled.bytecode.clone(), 0.into())?;
+                let (addr, _, _) = evm
+                    .deploy(deployer, compiled.bytecode.clone(), 0.into())
+                    .wrap_err(format!("could not deploy {}", name))?;
                 Ok((name.clone(), addr))
             })
             .collect::<Result<HashMap<_, _>>>()?;

--- a/dapp/src/runner.rs
+++ b/dapp/src/runner.rs
@@ -7,7 +7,7 @@ use ethers::{
 
 use evm_adapters::{fuzz::FuzzedExecutor, Evm, EvmError};
 
-use eyre::Result;
+use eyre::{Context, Result};
 use regex::Regex;
 use std::{collections::HashMap, time::Instant};
 
@@ -128,7 +128,9 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
         let should_fail = func.name.starts_with("testFail");
         // call the setup function in each test to reset the test's state.
         if setup {
-            self.evm.setup(self.address)?;
+            self.evm
+                .setup(self.address)
+                .wrap_err(format!("could not setup during {} test", func.name))?;
         }
 
         let (status, reason, gas_used) = match self.evm.call::<(), _, _>(

--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -57,7 +57,11 @@ fn main() -> eyre::Result<()> {
                 EvmType::Sputnik => {
                     use evm_adapters::sputnik::Executor;
                     use sputnik::backend::MemoryBackend;
-                    let cfg = evm_version.sputnik_cfg();
+                    let mut cfg = evm_version.sputnik_cfg();
+
+                    // We disable the contract size limit by default, because Solidity
+                    // test smart contracts are likely to be >24kb
+                    cfg.create_contract_limit = None;
 
                     let vicinity = if let Some(ref url) = fork_url {
                         let provider = Provider::try_from(url.as_str())?;

--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -32,6 +32,8 @@ fn main() -> eyre::Result<()> {
             no_compile,
             fork_url,
             fork_block_number,
+            initial_balance,
+            deployer,
         } => {
             // get the remappings / paths
             let remappings = utils::merge(remappings, remappings_env);
@@ -49,6 +51,8 @@ fn main() -> eyre::Result<()> {
                 .libraries(&lib_paths)
                 .out_path(out_path)
                 .fuzzer(fuzzer)
+                .initial_balance(initial_balance)
+                .deployer(deployer)
                 .skip_compilation(no_compile);
 
             // run the tests depending on the chosen EVM

--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -1,5 +1,8 @@
 use ethers::prelude::Provider;
-use evm_adapters::sputnik::{vicinity, ForkMemoryBackend};
+use evm_adapters::{
+    sputnik::{vicinity, ForkMemoryBackend},
+    FAUCET_ACCOUNT,
+};
 use regex::Regex;
 use sputnik::backend::Backend;
 use structopt::StructOpt;
@@ -8,6 +11,7 @@ use dapp::MultiContractRunnerBuilder;
 use dapp_solc::SolcBuilder;
 
 use ansi_term::Colour;
+use ethers::types::U256;
 
 mod dapp_opts;
 use dapp_opts::{BuildOpts, EvmType, Opts, Subcommands};
@@ -74,7 +78,11 @@ fn main() -> eyre::Result<()> {
                     } else {
                         env.sputnik_state()
                     };
-                    let backend = MemoryBackend::new(&vicinity, Default::default());
+                    let mut backend = MemoryBackend::new(&vicinity, Default::default());
+                    // max out the balance of the faucet
+                    let faucet =
+                        backend.state_mut().entry(*FAUCET_ACCOUNT).or_insert_with(Default::default);
+                    faucet.balance = U256::MAX;
 
                     let backend: Box<dyn Backend> = if let Some(ref url) = fork_url {
                         let provider = Provider::try_from(url.as_str())?;

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -52,6 +52,20 @@ pub enum Subcommands {
 
         #[structopt(help = "pins the block number for the state fork", long)]
         fork_block_number: Option<u64>,
+
+        #[structopt(
+            help = "the initial balance of each deployed test contract",
+            long,
+            default_value = "0xffffffffffffffffffffffff"
+        )]
+        initial_balance: U256,
+
+        #[structopt(
+            help = "the address which will be executing all tests",
+            long,
+            default_value = "0x0000000000000000000000000000000000000000"
+        )]
+        deployer: Address,
     },
     #[structopt(about = "build your smart contracts")]
     Build {

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -167,7 +167,9 @@ impl FromStr for EvmVersion {
 
 #[derive(Debug, StructOpt)]
 pub struct Env {
-    #[structopt(help = "the block gas limit", long, default_value = "25000000")]
+    // structopt does not let use `u64::MAX`:
+    // https://doc.rust-lang.org/std/primitive.u64.html#associatedconstant.MAX
+    #[structopt(help = "the block gas limit", long, default_value = "18446744073709551615")]
     pub gas_limit: u64,
 
     #[structopt(help = "the chainid opcode value", long, default_value = "1")]

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -11,6 +11,7 @@ pub struct Opts {
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Build, test, fuzz, formally verify, debug & deploy solidity contracts.")]
+#[allow(clippy::large_enum_variant)]
 pub enum Subcommands {
     #[structopt(about = "test your smart contracts")]
     Test {

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -1,6 +1,6 @@
 use structopt::StructOpt;
 
-use ethers::types::Address;
+use ethers::types::{Address, U256};
 use std::{path::PathBuf, str::FromStr};
 
 #[derive(Debug, StructOpt)]

--- a/dapptools/src/utils.rs
+++ b/dapptools/src/utils.rs
@@ -11,8 +11,6 @@ pub fn subscriber() {
     tracing_subscriber::FmtSubscriber::builder()
         // .with_timer(tracing_subscriber::fmt::time::uptime())
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        // don't need the target
-        .with_target(false)
         .init();
 }
 

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -53,6 +53,7 @@ impl<'a, S, E: Evm<S>> FuzzedExecutor<'a, E, S> {
         let pre_test_state = self.evm.borrow().state().clone();
 
         let mut runner = self.runner.clone();
+        tracing::debug!(func = ?func.name, should_fail, "fuzzing");
         runner.run(&strat, |calldata| {
             let mut evm = self.evm.borrow_mut();
 
@@ -86,7 +87,10 @@ pub fn fuzz_calldata(func: &Function) -> impl Strategy<Value = Bytes> + '_ {
     // possible combinations
     let strats = func.inputs.iter().map(|input| fuzz_param(&input.kind)).collect::<Vec<_>>();
 
-    strats.prop_map(move |tokens| func.encode_input(&tokens).unwrap().into())
+    strats.prop_map(move |tokens| {
+        tracing::trace!(input = ?tokens);
+        func.encode_input(&tokens).unwrap().into()
+    })
 }
 
 /// The max length of arrays we fuzz for is 256.

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -67,8 +67,8 @@ pub trait Evm<State> {
         tracing::debug!(?from, ?to, func = ?func.name, "calling");
         let (retdata, status, gas) = self.call_unchecked(from, to, &func, args, value)?;
         if Self::is_fail(&status) {
-            tracing::error!(?status, "failed");
             let reason = dapp_utils::decode_revert(retdata.as_ref()).map_err(AbiError::from)?;
+            tracing::error!(?status, ?reason, "failed");
             Err(EvmError::Execution { reason, gas_used: gas })
         } else {
             tracing::trace!(?status, ?retdata, "success");

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -72,14 +72,11 @@ pub trait Evm<State> {
         value: U256,
     ) -> std::result::Result<(D, Self::ReturnReason, u64), EvmError> {
         let func = func.into();
-        tracing::debug!(?from, ?to, func = ?func.name, "calling");
         let (retdata, status, gas) = self.call_unchecked(from, to, &func, args, value)?;
         if Self::is_fail(&status) {
             let reason = dapp_utils::decode_revert(retdata.as_ref()).map_err(AbiError::from)?;
-            tracing::error!(?status, ?reason, "failed");
             Err(EvmError::Execution { reason, gas_used: gas })
         } else {
-            tracing::trace!(?status, ?retdata, "success");
             let retdata = decode_function_data(&func, retdata, false)?;
             Ok((retdata, status, gas))
         }

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -20,6 +20,11 @@ use ethers::{
 use dapp_utils::IntoFunction;
 
 use eyre::Result;
+use once_cell::sync::Lazy;
+
+// The account that we use to fund all the deployed contracts
+pub static FAUCET_ACCOUNT: Lazy<Address> =
+    Lazy::new(|| Address::from_slice(&ethers::utils::keccak256("turbodapp faucet")[12..]));
 
 #[derive(thiserror::Error, Debug)]
 pub enum EvmError {

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -52,6 +52,9 @@ pub trait Evm<State> {
     /// Gets a reference to the current state of the EVM
     fn state(&self) -> &State;
 
+    /// Sets the balance at the specified address
+    fn set_balance(&mut self, address: Address, amount: U256);
+
     /// Resets the EVM's state to the provided value
     fn reset(&mut self, state: State);
 

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -68,7 +68,7 @@ where
     }
 
     fn is_fail(reason: &Self::ReturnReason) -> bool {
-        matches!(reason, ExitReason::Revert(_))
+        !Self::is_success(reason)
     }
 
     fn reset(&mut self, state: S) {

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -107,6 +107,11 @@ where
         let gas_after = self.executor.gas_left();
         let gas = gas_before.saturating_sub(gas_after).saturating_sub(21000.into());
 
+        if Self::is_fail(&status) {
+            // TODO: Should we be adding more context?
+            return Err(eyre::eyre!("deployment reverted"))
+        }
+
         Ok((address, status, gas.as_u64()))
     }
 

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -1,11 +1,11 @@
-use crate::Evm;
+use crate::{Evm, FAUCET_ACCOUNT};
 
 use ethers::types::{Address, Bytes, U256};
 
 use sputnik::{
     backend::{Backend, MemoryAccount},
     executor::{MemoryStackState, StackExecutor, StackState, StackSubstateMetadata},
-    Config, CreateScheme, ExitReason, ExitRevert,
+    Config, CreateScheme, ExitReason, ExitRevert, Transfer,
 };
 use std::{collections::BTreeMap, marker::PhantomData};
 
@@ -83,6 +83,13 @@ where
         contracts.into_iter().for_each(|(address, bytecode)| {
             state_.set_code(address, bytecode.to_vec());
         })
+    }
+
+    fn set_balance(&mut self, address: Address, balance: U256) {
+        self.executor
+            .state_mut()
+            .transfer(Transfer { source: *FAUCET_ACCOUNT, target: address, value: balance })
+            .expect("could not transfer funds")
     }
 
     fn state(&self) -> &S {

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -108,11 +108,12 @@ where
         let gas = gas_before.saturating_sub(gas_after).saturating_sub(21000.into());
 
         if Self::is_fail(&status) {
-            // TODO: Should we be adding more context?
-            return Err(eyre::eyre!("deployment reverted"))
+            tracing::trace!(?status, "failed");
+            Err(eyre::eyre!("deployment reverted, reason: {:?}", status))
+        } else {
+            tracing::trace!(?status, ?address, ?gas, "success");
+            Ok((address, status, gas.as_u64()))
         }
-
-        Ok((address, status, gas.as_u64()))
     }
 
     /// Runs the selected function


### PR DESCRIPTION
This PR Does a few things:
1. bump gas limit by default to u64::MAX
2. allow contracts to be over 24kb
3. when testing, only deploy contracts with 0 constructor arguments and if they have a function that matches`test.*`
4. adds a bunch of extra tracing so that we can make sense of what's going on: `RUST_LOG=dapp=trace,evm_adapters=trace cargo run -- ...`
5. returns a proper error when deployment fails

Here's an example of how tracing looks like now when used with [LootLoose](https://github.com/gakonst/lootloose/)
![image](https://user-images.githubusercontent.com/17802178/136700625-f70a58c1-bbc6-42e3-bac9-b920fb6d6b03.png)
