### PR TITLE
feat: ffi cheatcode

### DIFF
--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -40,6 +40,7 @@ fn main() -> eyre::Result<()> {
             fork_block_number,
             initial_balance,
             deployer,
+            ffi,
         } => {
             // get the remappings / paths
             let remappings = utils::merge(remappings, remappings_env);
@@ -95,7 +96,7 @@ fn main() -> eyre::Result<()> {
                     };
                     let backend = Arc::new(backend);
 
-                    let evm = Executor::new_with_cheatcodes(backend, env.gas_limit, &cfg);
+                    let evm = Executor::new_with_cheatcodes(backend, env.gas_limit, &cfg, ffi);
                     test(builder, evm, pattern, json)?;
                 }
                 #[cfg(feature = "evmodin-evm")]

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -67,6 +67,9 @@ pub enum Subcommands {
             default_value = "0x0000000000000000000000000000000000000000"
         )]
         deployer: Address,
+
+        #[structopt(help = "enables the FFI cheatcode", long)]
+        ffi: bool,
     },
     #[structopt(about = "build your smart contracts")]
     Build {

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -14,7 +14,7 @@ pub mod fuzz;
 use ethers::{
     abi::{Detokenize, Tokenize},
     core::types::{Address, U256},
-    prelude::{decode_function_data, encode_function_data, AbiError, Bytes},
+    prelude::{decode_function_data, encode_function_data, Bytes},
 };
 
 use dapp_utils::IntoFunction;

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -47,6 +47,10 @@ pub static HEVM: Lazy<BaseContract> = Lazy::new(|| {
             "store(address,bytes32,bytes32)",
             // returns the `value` of the storage `slot` at `address`
             "load(address,bytes32)(bytes32)",
+            // allows Solidity tests to make system calls on the host. Disabled
+            // by default, requires the user to enable it since it can be used
+            // to execute commands on a machine by adversaries
+            "ffi(string[])(bytes)",
         ])
         .expect("could not parse hevm cheatcode abi"),
     )

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -112,13 +112,14 @@ contract CheatCodes is DSTest {
     //     hevm.addr(0);
     // }
 
-    // function testFFI() public {
-    //     string[] memory inputs = new string[](3);
-    //     inputs[0] = "echo";
-    //     inputs[1] = "-n";
-    //     inputs[2] = "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046163616200000000000000000000000000000000000000000000000000000000";
+    function testFFI() public {
+        string[] memory inputs = new string[](3);
+        inputs[0] = "echo";
+        inputs[1] = "-n";
+        inputs[2] = "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046163616200000000000000000000000000000000000000000000000000000000";
 
-    //     (string memory output) = abi.decode(hevm.ffi(inputs), (string));
-    //     assertEq(output, "acab");
-    // }
+        bytes memory res = hevm.ffi(inputs);
+        (string memory output) = abi.decode(res, (string));
+        assertEq(output, "acab");
+    }
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -56,8 +56,9 @@ pub fn remove_extra_costs(gas: U256, calldata: &[u8]) -> U256 {
 }
 
 pub fn decode_revert(error: &[u8]) -> std::result::Result<String, ethers_core::abi::Error> {
-    if error.len() > 4 {
-        Ok(abi::decode(&[abi::ParamType::String], &error[4..])?[0].to_string())
+    let error = error.strip_prefix(&ethers_core::utils::id("Error(string)")).unwrap_or(error);
+    if !error.is_empty() {
+        Ok(abi::decode(&[abi::ParamType::String], &error)?[0].to_string())
     } else {
         Ok("No revert reason found".to_owned())
     }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -58,7 +58,7 @@ pub fn remove_extra_costs(gas: U256, calldata: &[u8]) -> U256 {
 pub fn decode_revert(error: &[u8]) -> std::result::Result<String, ethers_core::abi::Error> {
     let error = error.strip_prefix(&ethers_core::utils::id("Error(string)")).unwrap_or(error);
     if !error.is_empty() {
-        Ok(abi::decode(&[abi::ParamType::String], &error)?[0].to_string())
+        Ok(abi::decode(&[abi::ParamType::String], error)?[0].to_string())
     } else {
         Ok("No revert reason found".to_owned())
     }


### PR DESCRIPTION
* Adds a `ffi(string[])` which allows calling shell commands on the host
* Since this can be used for RCE e.g. if you download a phished test suite, we add a `--ffi` command on the CLI for enabling it explicitly