### PR TITLE
feat: remappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
  "hex",
  "hmac",
  "pbkdf2",
- "rand",
+ "rand 0.8.4",
  "sha2 0.9.8",
  "thiserror",
 ]
@@ -565,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d12477e115c0d570c12a2dfd859f80b55b60ddb5075df210d3af06d133a69f45"
 dependencies = [
  "generic-array 0.14.4",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
@@ -662,6 +662,7 @@ dependencies = [
  "evmodin",
  "eyre",
  "git2",
+ "glob",
  "proptest",
  "regex",
  "rpassword",
@@ -669,6 +670,7 @@ dependencies = [
  "serde_json",
  "seth",
  "structopt",
+ "tempdir",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -773,7 +775,7 @@ dependencies = [
  "generic-array 0.14.4",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
@@ -836,7 +838,7 @@ dependencies = [
  "hex",
  "hmac",
  "pbkdf2",
- "rand",
+ "rand 0.8.4",
  "scrypt",
  "serde",
  "serde_json",
@@ -992,7 +994,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "rand",
+ "rand 0.8.4",
  "rlp",
  "rlp-derive",
  "semver 1.0.4",
@@ -1082,7 +1084,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "hex",
- "rand",
+ "rand 0.8.4",
  "sha2 0.9.8",
  "thiserror",
 ]
@@ -1208,7 +1210,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -1219,7 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.4",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1254,6 +1256,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -1458,7 +1466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -2125,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e0b28ace46c5a396546bcf443bf422b57049617433d8854227352a4a9b24e7"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -2327,7 +2335,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand",
+ "rand 0.8.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2370,13 +2378,26 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
  "rand_hc",
 ]
 
@@ -2387,8 +2408,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2405,7 +2441,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2414,7 +2450,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2440,6 +2476,15 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2913,7 +2958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3078,7 +3123,7 @@ dependencies = [
  "indicatif",
  "itertools",
  "once_cell",
- "rand",
+ "rand 0.8.4",
  "reqwest",
  "semver 1.0.4",
  "serde",
@@ -3119,6 +3164,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,7 +3181,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/dapptools/Cargo.toml
+++ b/dapptools/Cargo.toml
@@ -32,6 +32,10 @@ sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  op
 evmodin = { git = "https://github.com/vorot93/evmodin", optional = true }
 proptest = "1.0.0"
 git2 = "0.13.22"
+glob = "0.3.0"
+
+[dev-dependencies]
+tempdir = "0.3.7"
 
 [features]
 default = ["sputnik-evm", "evmodin-evm"]

--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -43,7 +43,12 @@ fn main() -> eyre::Result<()> {
             deployer,
             ffi,
         } => {
-            // get the remappings / paths
+            // if no env var for remappings is provided, try calculating them on the spot
+            let remappings = if remappings_env.is_none() {
+                [remappings, utils::Remapping::find_many_str("lib")?].concat()
+            } else {
+                remappings
+            };
             let remappings = utils::merge(remappings, remappings_env);
             let lib_paths = utils::default_path(lib_paths)?;
 

--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -15,6 +15,7 @@ use ethers::types::U256;
 
 mod dapp_opts;
 use dapp_opts::{BuildOpts, EvmType, Opts, Subcommands};
+use utils::Remapping;
 
 use crate::dapp_opts::FullContractInfo;
 use std::{collections::HashMap, convert::TryFrom, path::Path, sync::Arc};
@@ -233,6 +234,10 @@ fn main() -> eyre::Result<()> {
 
                 Ok(())
             })?
+        }
+        Subcommands::Remappings => {
+            let remappings = Remapping::find_many("lib")?;
+            remappings.iter().for_each(|mapping| println!("{}={}", mapping.name, mapping.path))
         }
     }
 

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -90,6 +90,8 @@ pub enum Subcommands {
         )]
         dependencies: Vec<Dependency>,
     },
+    #[structopt(about = "prints the automatically inferred remappings for this repository")]
+    Remappings,
     #[structopt(about = "build your smart contracts. Requires `ETHERSCAN_API_KEY` to be set.")]
     VerifyContract {
         #[structopt(help = "contract source info `<path>:<contractname>`")]

--- a/dapptools/src/utils.rs
+++ b/dapptools/src/utils.rs
@@ -76,6 +76,11 @@ impl Remapping {
         }
     }
 
+    pub fn find_many_str(path: &str) -> eyre::Result<Vec<String>> {
+        let remappings = Self::find_many(path)?;
+        Ok(remappings.iter().map(|mapping| format!("{}={}", mapping.name, mapping.path)).collect())
+    }
+
     /// Gets all the remappings detected
     pub fn find_many(path: &str) -> eyre::Result<Vec<Self>> {
         let path = std::path::Path::new(path);

--- a/dapptools/src/utils.rs
+++ b/dapptools/src/utils.rs
@@ -44,6 +44,53 @@ pub fn merge(mut remappings: Vec<String>, remappings_env: Option<String>) -> Vec
     remappings
 }
 
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Remapping {
+    pub name: String,
+    pub path: String,
+}
+
+const DAPPTOOLS_CONTRACTS_DIR: &str = "src";
+const JS_CONTRACTS_DIR: &str = "contracts";
+
+impl Remapping {
+    fn find(name: &str) -> eyre::Result<Self> {
+        Self::find_with_type(name, DAPPTOOLS_CONTRACTS_DIR)
+            .or_else(|_| Self::find_with_type(name, JS_CONTRACTS_DIR))
+    }
+
+    fn find_with_type(name: &str, source: &str) -> eyre::Result<Self> {
+        let pattern = format!("{}/{}/**/*.sol", name, source);
+        let mut dapptools_contracts = glob::glob(&pattern)?;
+        if dapptools_contracts.next().is_some() {
+            let path = format!("{}/{}/", name, source);
+            let mut name = name
+                .split('/')
+                .last()
+                .ok_or_else(|| eyre::eyre!("repo name not found"))?
+                .to_string();
+            name.push('/');
+            Ok(Remapping { name, path })
+        } else {
+            eyre::bail!("no contracts found under {}", pattern)
+        }
+    }
+
+    /// Gets all the remappings detected
+    pub fn find_many(path: &str) -> eyre::Result<Vec<Self>> {
+        let path = std::path::Path::new(path);
+        let paths = std::fs::read_dir(path)?;
+        let remappings = paths
+            .into_iter()
+            // TODO: Surely there must be a better way to convert to str
+            .map(|path| Self::find(&path?.path().display().to_string()))
+            // Do we want to silently ignore the errors?
+            .filter_map(|x| x.ok())
+            .collect();
+        Ok(remappings)
+    }
+}
+
 /// Opens the file at `out_path` for R/W and creates it if it doesn't exist.
 pub fn open_file(out_path: PathBuf) -> eyre::Result<File> {
     Ok(if out_path.is_file() {
@@ -127,4 +174,52 @@ pub fn find_dapp_json_contract(path: &str, name: &str) -> eyre::Result<Contract>
     };
 
     Ok(serde_json::from_value(contract)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // https://doc.rust-lang.org/rust-by-example/std_misc/fs.html
+    fn touch(path: &std::path::Path) -> std::io::Result<()> {
+        match std::fs::OpenOptions::new().create(true).write(true).open(path) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    #[test]
+    fn remappings() {
+        let tmp_dir = tempdir::TempDir::new("lib").unwrap();
+        let repo1 = tmp_dir.path().join("src_repo");
+        let repo2 = tmp_dir.path().join("contracts_repo");
+
+        let dir1 = repo1.join("src");
+        std::fs::create_dir_all(&dir1).unwrap();
+
+        let dir2 = repo2.join("contracts");
+        std::fs::create_dir_all(&dir2).unwrap();
+
+        let contract1 = dir1.join("contract.sol");
+        touch(&contract1).unwrap();
+
+        let contract2 = dir2.join("contract.sol");
+        touch(&contract2).unwrap();
+
+        let path = tmp_dir.path().display().to_string();
+        let remappings = Remapping::find_many(&path).unwrap();
+        assert_eq!(
+            remappings,
+            vec![
+                Remapping {
+                    name: "src_repo/".to_string(),
+                    path: format!("{}/", dir1.into_os_string().into_string().unwrap())
+                },
+                Remapping {
+                    name: "contracts_repo/".to_string(),
+                    path: format!("{}/", dir2.into_os_string().into_string().unwrap())
+                },
+            ]
+        );
+    }
 }


### PR DESCRIPTION
* adds `dapp remappings` command which prints out the solc remappings. notably, this also supports non-dapptools-`src` repositories, e.g. hardhat/truffle where the contracts are under the `contracts/` dir.  relevant impl here: https://github.com/dapphub/dapptools/blob/b8958a0f01f8f2bde0b489e9793e86e3a8f9a044/src/dapp/libexec/dapp/dapp-remappings
* makes `dapp test` calculate the remappings in-place if no `DAPP_REMAPPINGS` env var is present