### PR TITLE
add DAPP_SRC as env var

### DIFF
--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -31,7 +31,15 @@ fn main() -> eyre::Result<()> {
     match opts.sub {
         Subcommands::Test {
             opts:
-                BuildOpts { contracts, remappings, remappings_env, lib_paths, out_path, evm_version },
+                BuildOpts {
+                    contracts,
+                    remappings,
+                    remappings_env,
+                    lib_paths,
+                    out_path,
+                    evm_version,
+                    contracts_env,
+                },
             env,
             json,
             pattern,
@@ -50,6 +58,13 @@ fn main() -> eyre::Result<()> {
             } else {
                 remappings
             };
+
+            let contracts = if let Some(env_defined_contracts) = contracts_env {
+                env_defined_contracts
+            } else {
+                contracts
+            };
+
             let remappings = utils::merge(remappings, remappings_env);
             let lib_paths = utils::default_path(lib_paths)?;
 
@@ -125,11 +140,24 @@ fn main() -> eyre::Result<()> {
         }
         Subcommands::Build {
             opts:
-                BuildOpts { contracts, remappings, remappings_env, lib_paths, out_path, evm_version: _ },
+                BuildOpts {
+                    contracts,
+                    remappings,
+                    remappings_env,
+                    lib_paths,
+                    out_path,
+                    evm_version: _,
+                    contracts_env,
+                },
         } => {
             // build the contracts
             let remappings = utils::merge(remappings, remappings_env);
             let lib_paths = utils::default_path(lib_paths)?;
+            let contracts = if let Some(env_defined_contracts) = contracts_env {
+                env_defined_contracts
+            } else {
+                contracts
+            };
             // TODO: Do we also want to include the file path in the contract map so
             // that we're more compatible with dapptools' artifact?
             let contracts = SolcBuilder::new(&contracts, &remappings, &lib_paths)?.build_all()?;

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -163,6 +163,8 @@ pub struct BuildOpts {
         default_value = "./src/**/*.sol"
     )]
     pub contracts: String,
+    #[structopt(env = "DAPP_SRC")]
+    pub contracts_env: Option<String>,
 
     #[structopt(help = "the remappings", long, short)]
     pub remappings: Vec<String>,


### PR DESCRIPTION
Adds DAPP_SRC as an env variable to match dapptools. Note: currently since contracts is not an `Option`, we don't know if the user explicitly passed in something on the command line or are using the default (we could check if they pass the default value, but the user may have put it in). This forces us to give priority to the environment variable 