### PR TITLE
fix build

### DIFF
--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -270,7 +270,7 @@ fn test<S: Clone, E: evm_adapters::Evm<S>>(
                 println!()
             }
             if !tests.is_empty() {
-                let term = if tests.len() > 1 {"tests"}.to_string() else {"test"}.to_string(); 
+                let term = if tests.len() > 1 {"tests"} else {"test"};
                 println!("Running {} {} for {}", tests.len(), term, contract_name);
             }
 


### PR DESCRIPTION
This removes some `to_string` calls after an `if` statement, which caused compilation to fail. After removal, `cargo build` succeeds.