### PR TITLE
fix(evm-adapters): init forked backend cache with local state

### DIFF
--- a/dapptools/src/dapp.rs
+++ b/dapptools/src/dapp.rs
@@ -96,7 +96,13 @@ fn main() -> eyre::Result<()> {
 
                     let backend: Box<dyn Backend> = if let Some(ref url) = fork_url {
                         let provider = Provider::try_from(url.as_str())?;
-                        let backend = ForkMemoryBackend::new(provider, backend, fork_block_number);
+                        let init_state = backend.state().clone();
+                        let backend = ForkMemoryBackend::new(
+                            provider,
+                            backend,
+                            fork_block_number,
+                            init_state,
+                        );
                         Box::new(backend)
                     } else {
                         Box::new(backend)

--- a/evm-adapters/src/sputnik/forked_backend/rpc.rs
+++ b/evm-adapters/src/sputnik/forked_backend/rpc.rs
@@ -40,7 +40,12 @@ impl<B: Backend, M: Middleware> ForkMemoryBackend<B, M>
 where
     M::Error: 'static,
 {
-    pub fn new(provider: M, backend: B, pin_block: Option<u64>) -> Self {
+    pub fn new(
+        provider: M,
+        backend: B,
+        pin_block: Option<u64>,
+        init_cache: BTreeMap<H160, MemoryAccount>
+    ) -> Self {
         let provider = BlockingProvider::new(provider);
         let pin_block = pin_block.unwrap_or_else(|| backend.block_number().as_u64()).into();
 
@@ -51,7 +56,7 @@ where
         Self {
             provider,
             backend,
-            cache: Default::default(),
+            cache: RefCell::new(init_cache),
             pin_block: Some(pin_block),
             pin_block_meta: block,
             chain_id,
@@ -202,7 +207,7 @@ mod tests {
         let blk = Some(13292465);
         let vicinity = rt.block_on(vicinity(&provider, blk)).unwrap();
         let backend = new_backend(&vicinity, Default::default());
-        let backend = ForkMemoryBackend::new(provider, backend, blk);
+        let backend = ForkMemoryBackend::new(provider, backend, blk, Default::default());
 
         let mut evm = Executor::new(12_000_000, &cfg, &backend);
 

--- a/evm-adapters/src/sputnik/forked_backend/rpc.rs
+++ b/evm-adapters/src/sputnik/forked_backend/rpc.rs
@@ -44,7 +44,7 @@ where
         provider: M,
         backend: B,
         pin_block: Option<u64>,
-        init_cache: BTreeMap<H160, MemoryAccount>
+        init_cache: BTreeMap<H160, MemoryAccount>,
     ) -> Self {
         let provider = BlockingProvider::new(provider);
         let pin_block = pin_block.unwrap_or_else(|| backend.block_number().as_u64()).into();

--- a/solc/src/lib.rs
+++ b/solc/src/lib.rs
@@ -382,7 +382,7 @@ mod tests {
             // update this test whenever there's a new sol
             // version. that's ok! good reminder to check the
             // patch notes.
-            (">=0.5.0", "0.8.9"),
+            (">=0.5.0", "0.8.10"),
             // range
             (">=0.4.0 <0.5.0", "0.4.26"),
         ]
@@ -426,7 +426,7 @@ mod tests {
         let versions = builder.contract_versions().unwrap();
         assert_eq!(versions["0.4.14"].len(), 2);
         assert_eq!(versions["0.4.26"].len(), 2);
-        assert_eq!(versions["0.8.9"].len(), 1);
+        assert_eq!(versions["0.8.10"].len(), 1);
 
         rmdir(&dir);
     }


### PR DESCRIPTION
Was getting `thread 'main' panicked at 'could not transfer funds: OutOfFund'` when I tried to run tests with `fork-url` set otherwise. Based on https://github.com/gakonst/dapptools-rs/pull/92 it seems like `ForkedMemoryBackend` will be replaced soon anyway, so maybe better to do an even more basic stopgap in the meantime?