### PR TITLE
fix: enable cheatcodes in the constructor

### DIFF
--- a/dapp/src/multi_runner.rs
+++ b/dapp/src/multi_runner.rs
@@ -43,7 +43,6 @@ impl MultiContractRunnerBuilder {
         E: Evm<S>,
     {
         let output = project.compile()?;
-        dbg!(&output.has_compiler_errors(), &output.is_unchanged());
         if output.has_compiler_errors() {
             // return the diagnostics error back to the user.
             eyre::bail!(output.to_string())

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -24,6 +24,7 @@ contract HasStorage {
 contract CheatCodes is DSTest {
     address public store = address(new HasStorage());
     Hevm constant hevm = Hevm(HEVM_ADDRESS);
+    address public who = hevm.addr(1);
 
     // Warp
 


### PR DESCRIPTION
Overrides the `transact_create` so that it uses our internal runtime which leverages the cheatcodes.