### PR TITLE
feat(seth): improve piped input support

### DIFF
--- a/dapptools/src/seth.rs
+++ b/dapptools/src/seth.rs
@@ -18,14 +18,16 @@ async fn main() -> eyre::Result<()> {
     let opts = Opts::from_args();
     match opts.sub {
         Subcommands::FromUtf8 { text } => {
-            println!("{}", SimpleSeth::from_utf8(&text));
+            let val = unwrap_or_stdin(text)?;
+            println!("{}", SimpleSeth::from_utf8(&val));
         }
         Subcommands::ToHex { decimal } => {
             let val = unwrap_or_stdin(decimal)?;
             println!("{}", SimpleSeth::hex(U256::from_dec_str(&val)?));
         }
         Subcommands::ToHexdata { input } => {
-            let output = match input {
+            let val = unwrap_or_stdin(input)?;
+            let output = match val {
                 s if s.starts_with('@') => {
                     let var = std::env::var(&s[1..])?;
                     var.as_bytes().to_hex()
@@ -45,16 +47,20 @@ async fn main() -> eyre::Result<()> {
             println!("0x{}", output);
         }
         Subcommands::ToCheckSumAddress { address } => {
-            println!("{}", SimpleSeth::checksum_address(&address)?);
+            let val = unwrap_or_stdin(address)?;
+            println!("{}", SimpleSeth::checksum_address(&val)?);
         }
         Subcommands::ToAscii { hexdata } => {
-            println!("{}", SimpleSeth::ascii(&hexdata)?);
+            let val = unwrap_or_stdin(hexdata)?;
+            println!("{}", SimpleSeth::ascii(&val)?);
         }
         Subcommands::ToBytes32 { bytes } => {
-            println!("{}", SimpleSeth::bytes32(&bytes)?);
+            let val = unwrap_or_stdin(bytes)?;
+            println!("{}", SimpleSeth::bytes32(&val)?);
         }
         Subcommands::ToDec { hexvalue } => {
-            println!("{}", SimpleSeth::to_dec(&hexvalue)?);
+            let val = unwrap_or_stdin(hexvalue)?;
+            println!("{}", SimpleSeth::to_dec(&val)?);
         }
         Subcommands::ToFix { decimals, value } => {
             let val = unwrap_or_stdin(value)?;
@@ -64,7 +70,8 @@ async fn main() -> eyre::Result<()> {
             );
         }
         Subcommands::ToUint256 { value } => {
-            println!("{}", SimpleSeth::to_uint256(value)?);
+            let val = unwrap_or_stdin(value)?;
+            println!("{}", SimpleSeth::to_uint256(&val)?);
         }
         Subcommands::ToWei { value, unit } => {
             let val = unwrap_or_stdin(value)?;
@@ -179,10 +186,9 @@ where
     Ok(match what {
         Some(what) => what,
         None => {
-            use std::io::Read;
-            let mut input = std::io::stdin();
+            let input = std::io::stdin();
             let mut what = String::new();
-            input.read_to_string(&mut what)?;
+            input.read_line(&mut what)?;
             T::from_str(&what.replace("\n", ""))?
         }
     })

--- a/dapptools/src/seth_opts.rs
+++ b/dapptools/src/seth_opts.rs
@@ -13,7 +13,7 @@ pub enum Subcommands {
     #[structopt(aliases = &["--from-ascii"])]
     #[structopt(name = "--from-utf8")]
     #[structopt(about = "convert text data into hexdata")]
-    FromUtf8 { text: String },
+    FromUtf8 { text: Option<String> },
     #[structopt(name = "--to-hex")]
     #[structopt(about = "convert a decimal number into hex")]
     ToHex { decimal: Option<String> },
@@ -26,25 +26,25 @@ pub enum Subcommands {
       - absolute path to file
       - @tag, where $TAG is defined in environment variables
     "#)]
-    ToHexdata { input: String },
+    ToHexdata { input: Option<String> },
     #[structopt(name = "--to-checksum-address")]
     #[structopt(about = "convert an address to a checksummed format (EIP-55)")]
-    ToCheckSumAddress { address: Address },
+    ToCheckSumAddress { address: Option<Address> },
     #[structopt(name = "--to-ascii")]
     #[structopt(about = "convert hex data to text data")]
-    ToAscii { hexdata: String },
+    ToAscii { hexdata: Option<String> },
     #[structopt(name = "--to-bytes32")]
     #[structopt(about = "left-pads a hex bytes string to 32 bytes)")]
-    ToBytes32 { bytes: String },
+    ToBytes32 { bytes: Option<String> },
     #[structopt(name = "--to-dec")]
     #[structopt(about = "convert hex value into decimal number")]
-    ToDec { hexvalue: String },
+    ToDec { hexvalue: Option<String> },
     #[structopt(name = "--to-fix")]
     #[structopt(about = "convert integers into fixed point with specified decimals")]
     ToFix { decimals: Option<u128>, value: Option<String> },
     #[structopt(name = "--to-uint256")]
     #[structopt(about = "convert a number into uint256 hex string with 0x prefix")]
-    ToUint256 { value: String },
+    ToUint256 { value: Option<String> },
     #[structopt(name = "--to-wei")]
     #[structopt(about = "convert an ETH amount into wei")]
     ToWei { value: Option<String>, unit: Option<String> },

--- a/seth/src/lib.rs
+++ b/seth/src/lib.rs
@@ -385,18 +385,18 @@ impl SimpleSeth {
     /// use seth::SimpleSeth as Seth;
     ///
     /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Seth::to_uint256("100".to_string())?, "0x0000000000000000000000000000000000000000000000000000000000000064");
-    ///     assert_eq!(Seth::to_uint256("192038293923".to_string())?, "0x0000000000000000000000000000000000000000000000000000002cb65fd1a3");
+    ///     assert_eq!(Seth::to_uint256("100")?, "0x0000000000000000000000000000000000000000000000000000000000000064");
+    ///     assert_eq!(Seth::to_uint256("192038293923")?, "0x0000000000000000000000000000000000000000000000000000002cb65fd1a3");
     ///     assert_eq!(
-    ///         Seth::to_uint256("115792089237316195423570985008687907853269984665640564039457584007913129639935".to_string())?,
+    ///         Seth::to_uint256("115792089237316195423570985008687907853269984665640564039457584007913129639935")?,
     ///         "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     ///     );
     ///
     ///     Ok(())
     /// }
     /// ```
-    pub fn to_uint256(value: String) -> Result<String> {
-        let num_u256 = U256::from_str_radix(&value, 10)?;
+    pub fn to_uint256(value: &str) -> Result<String> {
+        let num_u256 = U256::from_str_radix(value, 10)?;
         let num_hex = format!("{:x}", num_u256);
         Ok(format!("0x{}{}", "0".repeat(64 - num_hex.len()), num_hex))
     }


### PR DESCRIPTION
Resolves https://github.com/gakonst/dapptools-rs/issues/143

```console
➜  dapptools-rs git:(feat/piped-input) ✗ echo 'Foundry' | ./target/debug/seth --from-ascii                                 
0x466f756e647279

➜  dapptools-rs git:(feat/piped-input) ✗ echo '0x466f756e647279' | ./target/debug/seth --to-ascii                    
Foundry

➜  dapptools-rs git:(feat/piped-input) ✗ echo '0x466f756e647279' | ./target/debug/seth --to-bytes32                                   
0x466f756e64727900000000000000000000000000000000000000000000000000

➜  dapptools-rs git:(feat/piped-input) ✗ echo '466f756e647279' | ./target/debug/seth --to-hexdata
0x466f756e647279

➜  dapptools-rs git:(feat/piped-input) ✗ echo '0xb7e390864a90b7b923c9f9310c6f98aafe43f707' | ./target/debug/seth --to-checksum-address
0xB7e390864a90b7b923C9f9310C6F98aafE43F707

➜  dapptools-rs git:(feat/piped-input) ✗ echo '1337' | ./target/debug/seth --to-uint256
0x0000000000000000000000000000000000000000000000000000000000000539

➜  dapptools-rs git:(feat/piped-input) echo '0x539' | ./target/debug/seth --to-dec                                                             
1337
```